### PR TITLE
Order the clips grid by when each clip was last practised

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,14 +7,14 @@ import { browserClipCache, browserThumbnailCache } from './clips/clipCache'
 import type { ClipProbe } from './clips/clipProbe'
 import { browserClipProbe } from './clips/clipProbe'
 import { ClipsScreen } from './clips/ClipsScreen'
-import { withLoopCounts } from './clips/library'
+import { withLoopCounts, withPractised } from './clips/library'
 import type { ThumbnailCapture } from './clips/thumbnail'
 import { browserThumbnailCapture } from './clips/thumbnail'
 import { useLibrary } from './clips/useLibrary'
 import { useThumbnails } from './clips/useThumbnails'
 import type { DriveApi } from './drive/driveApi'
 import { browserDriveApi } from './drive/driveApi'
-import { countOf } from './loops/loopsChange'
+import { countOf, practisedAt } from './loops/loopsChange'
 import type { LoopsCache } from './loops/loopsCache'
 import { browserLoopsCache } from './loops/loopsCache'
 import { useLoops } from './loops/useLoops'
@@ -54,12 +54,13 @@ export function App({
      count in each tile and orders by it under **Most looped**. One `loops.json`
      holds every clip's, so there is one place to read it from (US-01-15). */
   const loops = useLoops(driveApi, loopsCache)
-  /* The clips as the grid draws them, counts included. The two arrive
-     separately — Drive's file listing knows nothing about loops, and
-     `loops.json` is fetched on its own — so this is where they are put
-     together, once, for both screens. */
-  const counted = withLoopCounts(library, (clipId) =>
-    countOf(loops.loops, clipId),
+  /* The clips as the grid draws them: counts, and when each was last practised
+     (#12). All of it arrives separately — Drive's file listing knows nothing
+     about loops, and `loops.json` is fetched on its own — so this is where they
+     are put together, once, for both screens. */
+  const counted = withPractised(
+    withLoopCounts(library, (clipId) => countOf(loops.loops, clipId)),
+    (clipId) => practisedAt(loops.loops, clipId),
   )
   /* Beside the loops, and above both routes for the same reason: the grid
      paints the stills and the player makes the ones that are missing, so a

--- a/app/src/clips/ClipsScreen.test.tsx
+++ b/app/src/clips/ClipsScreen.test.tsx
@@ -219,13 +219,14 @@ const gridOrder = () =>
     .map((link) => link.getAttribute('href')?.replace('/clip/', ''))
 
 describe('the ordering chips', () => {
-  it('offers the three orderings, in the order the dancer reads them', () => {
+  it('offers the four orderings, in the order the dancer reads them', () => {
     renderScreen([])
 
     expect(chips().map((chip) => chip.textContent)).toEqual([
       'Recent',
       'Name',
       'Most looped',
+      'Last practised',
     ])
   })
 
@@ -302,6 +303,51 @@ describe('the ordering chips', () => {
     ])
 
     await userEvent.click(screen.getByRole('button', { name: 'Most looped' }))
+
+    expect(gridOrder()).toEqual(['first', 'second', 'third'])
+  })
+
+  /* #12. **Recent** is the day a clip was uploaded and never changes again, so
+     a clip added in July and drilled last night sorts below six that were added
+     and never opened. This is the chip that answers "what am I working on". */
+  it('draws the most recently practised clip first when Last practised is chosen', async () => {
+    renderScreen([
+      getClip({ id: 'yesterday', practised: '2026-09-05T20:00:00.000Z' }),
+      getClip({ id: 'just-now', practised: '2026-09-06T18:04:11.000Z' }),
+      getClip({ id: 'last-week', practised: '2026-08-30T09:15:00.000Z' }),
+    ])
+
+    await userEvent.click(screen.getByRole('button', { name: 'Last practised' }))
+
+    expect(gridOrder()).toEqual(['just-now', 'yesterday', 'last-week'])
+  })
+
+  /* Most of a real library, and both halves of this matter. They sort last,
+     because never practised is not practised at the beginning of time. And they
+     are still drawn — a clip that fell out of the grid under one chip would
+     read as a clip that had been deleted. */
+  it('sorts the never-practised below every clip that has been, and draws them all', async () => {
+    renderScreen([
+      getClip({ id: 'never' }),
+      getClip({ id: 'worked-on', practised: '2026-08-30T09:15:00.000Z' }),
+      getClip({ id: 'never-either' }),
+    ])
+
+    await userEvent.click(screen.getByRole('button', { name: 'Last practised' }))
+
+    expect(gridOrder()).toEqual(['worked-on', 'never', 'never-either'])
+  })
+
+  it('leaves clips practised at the same moment in the order they arrived', async () => {
+    const at = '2026-09-06T18:04:11.000Z'
+
+    renderScreen([
+      getClip({ id: 'first', practised: at, name: 'Camel walk' }),
+      getClip({ id: 'second', practised: at, name: 'Body roll' }),
+      getClip({ id: 'third', practised: at, name: 'Arm wave' }),
+    ])
+
+    await userEvent.click(screen.getByRole('button', { name: 'Last practised' }))
 
     expect(gridOrder()).toEqual(['first', 'second', 'third'])
   })

--- a/app/src/clips/clip.ts
+++ b/app/src/clips/clip.ts
@@ -6,6 +6,15 @@ export type Clip = {
      arrived has a length that is unknown, not one that was never asked for. */
   readonly seconds?: number | undefined
   readonly loops: number
+  /* When a loop was last saved on this clip or removed from it (#12), which is
+     what the **Last practised** chip orders by. Comes from `loops.json` beside
+     the count above, and is undefined for the same two different reasons: the
+     dancer has never worked on this clip, or the file has not arrived yet.
+
+     Undefined rather than a fallback date, deliberately. "Never practised" is
+     not "practised at the beginning of time" — the chip sorts it below every
+     clip that has been, and any real date would let it tie with one. */
+  readonly practised?: string | undefined
   readonly src?: string | undefined
   /* Drive's own id for the file holding this clip's bytes, which is what a
      download is addressed by. Absent until the upload finishes — and absent

--- a/app/src/clips/library.test.ts
+++ b/app/src/clips/library.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
 import { getClip } from './clip.factory'
-import { adding, deleted, failed, LOADING, loaded, withLoopCounts } from './library'
+import {
+  adding,
+  deleted,
+  failed,
+  LOADING,
+  loaded,
+  withLoopCounts,
+  withPractised,
+} from './library'
 
 describe('what the library knows before it knows anything', () => {
   /* An empty grid would otherwise mean two different things — "you have no
@@ -124,5 +132,55 @@ describe('the count of loops saved against each clip', () => {
 
     expect(counted.state).toBe('ready')
     expect(counted.uploading).toEqual(twoClips.uploading)
+  })
+})
+
+/* The same join as the count above, for the same reason and from the same file
+   (#12): a Drive listing knows when a clip was uploaded and nothing about when
+   it was last worked on. Kept separate from `withLoopCounts` rather than folded
+   into it — two facts, arriving by the same route but answering to different
+   questions, and a function named for counting should not quietly do both. */
+describe('when each clip was last practised', () => {
+  const PRACTISED = '2026-09-06T18:04:11.000Z'
+
+  const twoClips = loaded(LOADING, [
+    getClip({ id: 'shuffle-drill' }),
+    getClip({ id: 'pivot-turn' }),
+  ])
+
+  it('gives each clip the moment it was last practised', () => {
+    const dated = withPractised(twoClips, (clipId) =>
+      clipId === 'shuffle-drill' ? PRACTISED : undefined,
+    )
+
+    expect(dated.clips.map(({ id, practised }) => [id, practised])).toEqual([
+      ['shuffle-drill', PRACTISED],
+      ['pivot-turn', undefined],
+    ])
+  })
+
+  it('leaves everything else about the clip alone', () => {
+    const clip = getClip({ id: 'shuffle-drill', loops: 2 })
+
+    expect(
+      withPractised(loaded(LOADING, [clip]), () => PRACTISED).clips[0],
+    ).toEqual({ ...clip, practised: PRACTISED })
+  })
+
+  /* Which is most of a real library, and the chip has to draw them: never
+     practised is a clip to sort last, not a clip to leave out. */
+  it('leaves a clip that has never been practised without a date', () => {
+    expect(
+      withPractised(twoClips, () => undefined).clips.map(
+        ({ practised }) => practised,
+      ),
+    ).toEqual([undefined, undefined])
+  })
+
+  it('keeps the rest of the library as it found it', () => {
+    const dated = withPractised(twoClips, () => PRACTISED)
+
+    expect(dated.state).toBe('ready')
+    expect(dated.uploading).toEqual(twoClips.uploading)
   })
 })

--- a/app/src/clips/library.ts
+++ b/app/src/clips/library.ts
@@ -128,3 +128,26 @@ export const withLoopCounts = (
   ...library,
   clips: library.clips.map((clip) => ({ ...clip, loops: countFor(clip.id) })),
 })
+
+/* The same join, for the other thing `loops.json` knows that a Drive listing
+   does not: when each clip was last worked on (#12).
+
+   A sibling of `withLoopCounts` rather than a second argument to it. They read
+   the same file and arrive by the same route, but they answer different
+   questions, and a function named for counting should not quietly do both —
+   composing the two at the one call site says what is happening more plainly
+   than a `countFor`/`practisedFor` pair would.
+
+   Undefined is a real answer here rather than a gap: most of a library has
+   never been practised, and the chip has to draw those clips rather than leave
+   them out. */
+export const withPractised = (
+  library: Library,
+  practisedFor: (clipId: string) => string | undefined,
+): Library => ({
+  ...library,
+  clips: library.clips.map((clip) => ({
+    ...clip,
+    practised: practisedFor(clip.id),
+  })),
+})

--- a/app/src/clips/ordering.ts
+++ b/app/src/clips/ordering.ts
@@ -16,6 +16,24 @@ export const orderings = [
     label: 'Most looped',
     compare: (a: Clip, b: Clip) => b.loops - a.loops,
   },
+  /* #12 — the chip that answers "what am I working on". **Recent** above is the
+     day a clip was uploaded and never changes again, so a clip added in July and
+     drilled last night sorts below six that were added and never opened.
+
+     `''` for a clip never practised, which puts the whole never-practised tail
+     below every clip that has been — most of a real library. A fallback date
+     would be worse than wrong: it would let one of them tie with a clip that
+     genuinely was practised then.
+
+     Last of the four rather than beside **Recent**, so `orderings[0]` stays
+     Recent — that is both the default and where the grid jumps back to after an
+     add (`ClipsScreen`). */
+  {
+    id: 'practised',
+    label: 'Last practised',
+    compare: (a: Clip, b: Clip) =>
+      (b.practised ?? '').localeCompare(a.practised ?? ''),
+  },
 ] as const
 
 export type OrderingId = (typeof orderings)[number]['id']

--- a/app/src/loops/applyToLoops.test.ts
+++ b/app/src/loops/applyToLoops.test.ts
@@ -12,6 +12,12 @@ import { NO_LOOPS, serialiseLoops } from './loopsFile'
 const A_CLIP = 'shuffle-drill'
 const THE_OTHER_CLIP = 'pivot-turn'
 
+/* When the change was made. Nothing here is about the stamp — that is
+   `loopsChange.test.ts` — but it rides every write, so it shows up in the
+   bodies these tests read back. */
+const AT = '2026-09-06T18:04:11.000Z'
+const PRACTISED = { [A_CLIP]: AT }
+
 const holding = (
   clips: Record<string, readonly SavedLoop[]>,
   versions: readonly string[] = ['3', '3'],
@@ -39,7 +45,7 @@ describe('writing a change back to Drive', () => {
     const api = holding({})
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, getLoop()),
+      withLoop(loops, A_CLIP, getLoop(), AT),
     )
 
     expect(api.writeJson).toHaveBeenCalledWith(
@@ -56,9 +62,13 @@ describe('writing a change back to Drive', () => {
 
     await expect(
       applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-        withLoop(loops, A_CLIP, loop),
+        withLoop(loops, A_CLIP, loop, AT),
       ),
-    ).resolves.toEqual({ ...NO_LOOPS, clips: { [A_CLIP]: [loop] } })
+    ).resolves.toEqual({
+      ...NO_LOOPS,
+      clips: { [A_CLIP]: [loop] },
+      touched: PRACTISED,
+    })
   })
 
   /* UC-01 Q-05, and the whole reason this is a read-modify-write rather than a
@@ -71,13 +81,13 @@ describe('writing a change back to Drive', () => {
     const api = holding({ [THE_OTHER_CLIP]: [theirs] })
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, mine),
+      withLoop(loops, A_CLIP, mine, AT),
     )
 
     expect(bodyWritten(api)).toEqual({
       schema: 1,
       clips: { [THE_OTHER_CLIP]: [theirs], [A_CLIP]: [mine] },
-      touched: {},
+      touched: PRACTISED,
     })
   })
 
@@ -87,13 +97,13 @@ describe('writing a change back to Drive', () => {
     const api = holding({ [A_CLIP]: [going, kept] })
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withoutLoop(loops, A_CLIP, 'going'),
+      withoutLoop(loops, A_CLIP, 'going', AT),
     )
 
     expect(bodyWritten(api)).toEqual({
       schema: 1,
       clips: { [A_CLIP]: [kept] },
-      touched: {},
+      touched: PRACTISED,
     })
   })
 })
@@ -104,7 +114,7 @@ describe('the first save of all', () => {
     const api = aDriveApi()
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, loop),
+      withLoop(loops, A_CLIP, loop, AT),
     )
 
     expect(api.createJson).toHaveBeenCalledWith(A_TOKEN, {
@@ -114,7 +124,7 @@ describe('the first save of all', () => {
     expect(bodyWritten(api)).toEqual({
       schema: 1,
       clips: { [A_CLIP]: [loop] },
-      touched: {},
+      touched: PRACTISED,
     })
   })
 })
@@ -130,7 +140,7 @@ describe('a file nobody can read', () => {
     })
 
     const refused = await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, getLoop()),
+      withLoop(loops, A_CLIP, getLoop(), AT),
     ).catch((error: unknown) => error)
 
     expect(refused).toBeInstanceOf(LoopsRefused)
@@ -146,7 +156,7 @@ describe('a write that lands inside our own round trip', () => {
     const api = holding({}, ['3', '4', '4', '4'])
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, getLoop()),
+      withLoop(loops, A_CLIP, getLoop(), AT),
     )
 
     expect(api.readJson).toHaveBeenCalledTimes(2)
@@ -159,7 +169,7 @@ describe('a write that lands inside our own round trip', () => {
     const api = holding({}, ['3', '4', '4', '5'])
 
     const refused = await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, getLoop()),
+      withLoop(loops, A_CLIP, getLoop(), AT),
     ).catch((error: unknown) => error)
 
     expect(refused).toBeInstanceOf(LoopsRefused)

--- a/app/src/loops/applyToLoops.test.ts
+++ b/app/src/loops/applyToLoops.test.ts
@@ -77,6 +77,7 @@ describe('writing a change back to Drive', () => {
     expect(bodyWritten(api)).toEqual({
       schema: 1,
       clips: { [THE_OTHER_CLIP]: [theirs], [A_CLIP]: [mine] },
+      touched: {},
     })
   })
 
@@ -92,6 +93,7 @@ describe('writing a change back to Drive', () => {
     expect(bodyWritten(api)).toEqual({
       schema: 1,
       clips: { [A_CLIP]: [kept] },
+      touched: {},
     })
   })
 })
@@ -112,6 +114,7 @@ describe('the first save of all', () => {
     expect(bodyWritten(api)).toEqual({
       schema: 1,
       clips: { [A_CLIP]: [loop] },
+      touched: {},
     })
   })
 })

--- a/app/src/loops/loopsChange.test.ts
+++ b/app/src/loops/loopsChange.test.ts
@@ -1,16 +1,28 @@
 import { describe, expect, it } from 'vitest'
 
 import { getLoop } from './loop.factory'
-import { countOf, loopsFor, withLoop, withoutLoop } from './loopsChange'
+import {
+  countOf,
+  loopsFor,
+  practisedAt,
+  withLoop,
+  withoutLoop,
+} from './loopsChange'
 import { NO_LOOPS } from './loopsFile'
 
 const A_CLIP = 'shuffle-drill'
 const ANOTHER_CLIP = 'pivot-turn'
 
-const holding = (clips: Record<string, ReturnType<typeof getLoop>[]>) => ({
-  ...NO_LOOPS,
-  clips,
-})
+/* When the change being made happened. Every one of these functions takes it
+   rather than reading a clock, so the merge below is testable as arithmetic. */
+const AT = '2026-09-06T18:04:11.000Z'
+const EARLIER = '2026-09-06T09:00:00.000Z'
+const LATER = '2026-09-06T21:30:00.000Z'
+
+const holding = (
+  clips: Record<string, ReturnType<typeof getLoop>[]>,
+  touched: Record<string, string> = {},
+) => ({ ...NO_LOOPS, clips, touched })
 
 /* These two are the whole of what a device ever does to `loops.json`, and that
    is the point: because the only changes are "append this one" and "drop this
@@ -20,7 +32,9 @@ describe('adding a loop', () => {
   it('starts the list for a clip that had none', () => {
     const loop = getLoop()
 
-    expect(withLoop(NO_LOOPS, A_CLIP, loop)).toEqual(holding({ [A_CLIP]: [loop] }))
+    expect(withLoop(NO_LOOPS, A_CLIP, loop, AT)).toEqual(
+      holding({ [A_CLIP]: [loop] }, { [A_CLIP]: AT }),
+    )
   })
 
   it('adds to the end, which is the order the panel lists them in', () => {
@@ -28,7 +42,7 @@ describe('adding a loop', () => {
     const second = getLoop({ id: 'second' })
 
     expect(
-      withLoop(holding({ [A_CLIP]: [first] }), A_CLIP, second).clips[A_CLIP],
+      withLoop(holding({ [A_CLIP]: [first] }), A_CLIP, second, AT).clips[A_CLIP],
     ).toEqual([first, second])
   })
 
@@ -39,7 +53,7 @@ describe('adding a loop', () => {
     const theirs = getLoop({ id: 'theirs' })
 
     expect(
-      withLoop(holding({ [ANOTHER_CLIP]: [theirs] }), A_CLIP, mine).clips,
+      withLoop(holding({ [ANOTHER_CLIP]: [theirs] }), A_CLIP, mine, AT).clips,
     ).toEqual({ [ANOTHER_CLIP]: [theirs], [A_CLIP]: [mine] })
   })
 })
@@ -50,8 +64,8 @@ describe('removing a loop', () => {
     const going = getLoop({ id: 'going' })
 
     expect(
-      withoutLoop(holding({ [A_CLIP]: [kept, going] }), A_CLIP, 'going'),
-    ).toEqual(holding({ [A_CLIP]: [kept] }))
+      withoutLoop(holding({ [A_CLIP]: [kept, going] }), A_CLIP, 'going', AT),
+    ).toEqual(holding({ [A_CLIP]: [kept] }, { [A_CLIP]: AT }))
   })
 
   /* Matches what the reader does with a clip whose every entry was malformed:
@@ -59,8 +73,13 @@ describe('removing a loop', () => {
      about what an empty list means. */
   it('drops the clip entirely once its last loop is gone', () => {
     expect(
-      withoutLoop(holding({ [A_CLIP]: [getLoop({ id: 'only' })] }), A_CLIP, 'only'),
-    ).toEqual(NO_LOOPS)
+      withoutLoop(
+        holding({ [A_CLIP]: [getLoop({ id: 'only' })] }),
+        A_CLIP,
+        'only',
+        AT,
+      ),
+    ).toEqual(holding({}, { [A_CLIP]: AT }))
   })
 
   it('leaves every other clip exactly as it was', () => {
@@ -71,8 +90,9 @@ describe('removing a loop', () => {
         holding({ [A_CLIP]: [getLoop({ id: 'mine' })], [ANOTHER_CLIP]: [theirs] }),
         A_CLIP,
         'mine',
+        AT,
       ),
-    ).toEqual(holding({ [ANOTHER_CLIP]: [theirs] }))
+    ).toEqual(holding({ [ANOTHER_CLIP]: [theirs] }, { [A_CLIP]: AT }))
   })
 
   /* Both of these happen for real: the other device removed it first, and the
@@ -80,11 +100,64 @@ describe('removing a loop', () => {
   it('is a no-op for an id that is not there', () => {
     const held = holding({ [A_CLIP]: [getLoop()] })
 
-    expect(withoutLoop(held, A_CLIP, 'never-saved')).toEqual(held)
+    expect(withoutLoop(held, A_CLIP, 'never-saved', AT).clips).toEqual(held.clips)
   })
 
   it('is a no-op for a clip that is not there', () => {
-    expect(withoutLoop(NO_LOOPS, 'no-such-clip', 'loop-1')).toEqual(NO_LOOPS)
+    expect(withoutLoop(NO_LOOPS, 'no-such-clip', 'loop-1', AT).clips).toEqual({})
+  })
+})
+
+/* #12 — the last time a loop was saved on a clip or removed from it, which is
+   what the **Last practised** chip orders by. The stamp rides the two writes
+   that already happen rather than adding a third, which is the whole reason
+   practising is defined as loop edits and not as opening the player. */
+describe('stamping a clip as practised', () => {
+  it('stamps the clip a loop was saved on', () => {
+    expect(withLoop(NO_LOOPS, A_CLIP, getLoop(), AT).touched).toEqual({
+      [A_CLIP]: AT,
+    })
+  })
+
+  /* A removal is working on the clip too, so it stamps — including the removal
+     that empties it. That is why the stamp is a sibling of `clips` rather than
+     a field on a loop: it has to outlive the loops it was made by. */
+  it('stamps the clip a loop was removed from, even as its last loop goes', () => {
+    const emptied = withoutLoop(
+      holding({ [A_CLIP]: [getLoop({ id: 'only' })] }),
+      A_CLIP,
+      'only',
+      AT,
+    )
+
+    expect(emptied.clips).toEqual({})
+    expect(emptied.touched).toEqual({ [A_CLIP]: AT })
+  })
+
+  it('moves the stamp on when the same clip is practised again', () => {
+    expect(
+      withLoop(holding({}, { [A_CLIP]: EARLIER }), A_CLIP, getLoop(), LATER)
+        .touched,
+    ).toEqual({ [A_CLIP]: LATER })
+  })
+
+  /* The merge rule, and the reason this is `max` rather than an assignment.
+     `applyToLoops` replays the change onto whatever Drive holds *now*, so a
+     stamp captured before that round trip can arrive after a newer one the
+     phone already wrote. Taking the later of the two is what stops the laptop
+     dragging a clip's recency backwards. */
+  it('leaves a later stamp standing when an earlier change is replayed onto it', () => {
+    expect(
+      withLoop(holding({}, { [A_CLIP]: LATER }), A_CLIP, getLoop(), EARLIER)
+        .touched,
+    ).toEqual({ [A_CLIP]: LATER })
+  })
+
+  it('leaves every other clip’s stamp exactly as it was', () => {
+    expect(
+      withLoop(holding({}, { [ANOTHER_CLIP]: EARLIER }), A_CLIP, getLoop(), AT)
+        .touched,
+    ).toEqual({ [ANOTHER_CLIP]: EARLIER, [A_CLIP]: AT })
   })
 })
 
@@ -111,5 +184,16 @@ describe('what a clip has', () => {
         A_CLIP,
       ),
     ).toBe(2)
+  })
+
+  it('says when it was last practised', () => {
+    expect(practisedAt(holding({}, { [A_CLIP]: AT }), A_CLIP)).toBe(AT)
+  })
+
+  /* Undefined rather than a fallback date. "Never practised" is not "practised
+     at the beginning of time" — the chip has to sort it below every clip that
+     has been, and a real date would let it tie with one. */
+  it('says nothing for a clip that has never been practised', () => {
+    expect(practisedAt(NO_LOOPS, 'no-such-clip')).toBeUndefined()
   })
 })

--- a/app/src/loops/loopsChange.test.ts
+++ b/app/src/loops/loopsChange.test.ts
@@ -153,6 +153,17 @@ describe('stamping a clip as practised', () => {
     ).toEqual({ [A_CLIP]: LATER })
   })
 
+  /* The rule `withClip` states and nothing else pins: a removal replayed onto a
+     file the other device has already removed from changes no loops, but the
+     dancer still pressed the button, so it still stamps. The two no-op tests
+     above assert only `.clips`, which is exactly what leaves this unguarded. */
+  it('stamps a removal that removes nothing', () => {
+    expect(
+      withoutLoop(holding({ [A_CLIP]: [getLoop()] }), A_CLIP, 'never-saved', AT)
+        .touched,
+    ).toEqual({ [A_CLIP]: AT })
+  })
+
   it('leaves every other clip’s stamp exactly as it was', () => {
     expect(
       withLoop(holding({}, { [ANOTHER_CLIP]: EARLIER }), A_CLIP, getLoop(), AT)

--- a/app/src/loops/loopsChange.ts
+++ b/app/src/loops/loopsChange.ts
@@ -13,14 +13,36 @@ import type { LoopsFile } from './loopsFile'
    Everything here is a plain function of a `LoopsFile`, so the same code path
    serves the optimistic local answer and the write that goes to Drive. */
 
+/* The later of the two, and a plain string comparison because the stamps are
+   ISO-8601 UTC — the one format whose lexical order is its chronological order.
+
+   `max` rather than an assignment, and that is the merge rule rather than
+   caution. `applyToLoops` replays this change onto whatever Drive holds *now*,
+   so a stamp captured before that round trip can land on top of a newer one the
+   phone already wrote. Assigning would let a laptop that has been offline drag
+   a clip's recency backwards. Two clocks that disagree cost minutes here, which
+   is nothing against a chip measured in days. */
+const laterOf = (held: string | undefined, at: string) =>
+  held !== undefined && held > at ? held : at
+
 /* A clip with no loops is not in the file at all, which is the same rule
    `readLoopsFile` applies to a clip whose every entry was malformed. Keeping an
    empty list would give the two readings of "this clip has nothing" a way to
-   disagree. */
+   disagree.
+
+   The stamp is not filtered the same way, on purpose: a clip whose last loop
+   has just been removed is a clip that was just practised, so its `touched`
+   entry outlives the loops that earned it (#12).
+
+   Every change through here stamps, with no exception for one that removes
+   nothing. A removal replayed onto a file the other device already removed from
+   changes no loops, but the dancer still pressed the button — the emptiness is
+   the merge's doing, not theirs. */
 const withClip = (
   loops: LoopsFile,
   clipId: string,
   saved: readonly SavedLoop[],
+  at: string,
 ): LoopsFile => ({
   ...loops,
   clips: Object.fromEntries(
@@ -28,6 +50,7 @@ const withClip = (
       ([, held]) => held.length > 0,
     ),
   ),
+  touched: { ...loops.touched, [clipId]: laterOf(loops.touched[clipId], at) },
 })
 
 export const loopsFor = (
@@ -42,24 +65,41 @@ export const loopsFor = (
 export const countOf = (loops: LoopsFile, clipId: string) =>
   loopsFor(loops, clipId).length
 
+/* What the **Last practised** chip orders by (#12). Undefined rather than a
+   fallback date, because "never practised" is not "practised at the beginning
+   of time": the chip sorts the never-practised below every clip that has been,
+   and any real date would let one of them tie with a clip that has. */
+export const practisedAt = (
+  loops: LoopsFile,
+  clipId: string,
+): string | undefined => loops.touched[clipId]
+
 /* At the end, because that is the order the panel lists them in and the order
-   the dancer saved them in. */
+   the dancer saved them in.
+
+   `at` is passed in rather than read from a clock here, which keeps this module
+   pure and — more usefully — makes the merge above something a test can state
+   as arithmetic rather than schedule. */
 export const withLoop = (
   loops: LoopsFile,
   clipId: string,
   loop: SavedLoop,
-): LoopsFile => withClip(loops, clipId, [...loopsFor(loops, clipId), loop])
+  at: string,
+): LoopsFile => withClip(loops, clipId, [...loopsFor(loops, clipId), loop], at)
 
 /* A no-op for an id that is not there, and that is a real case rather than
    defensiveness: the other device may have removed it first, and the merge
-   replays this removal onto a file that has already lost it. */
+   replays this removal onto a file that has already lost it. A no-op for the
+   loops — it still stamps, for the reason `withClip` gives. */
 export const withoutLoop = (
   loops: LoopsFile,
   clipId: string,
   id: string,
+  at: string,
 ): LoopsFile =>
   withClip(
     loops,
     clipId,
     loopsFor(loops, clipId).filter((loop) => loop.id !== id),
+    at,
   )

--- a/app/src/loops/loopsFile.test.ts
+++ b/app/src/loops/loopsFile.test.ts
@@ -3,8 +3,13 @@ import { describe, expect, it } from 'vitest'
 import { getLoop } from './loop.factory'
 import { NO_LOOPS, readLoopsFile, serialiseLoops } from './loopsFile'
 
-const written = (clips: Record<string, unknown>) =>
-  JSON.stringify({ schema: 1, clips })
+/* `JSON.stringify` drops an undefined value rather than writing `null`, so
+   omitting the second argument writes a file with no `touched` key at all —
+   which is every file written before #12. */
+const written = (clips: Record<string, unknown>, touched?: unknown) =>
+  JSON.stringify({ schema: 1, clips, touched })
+
+const PRACTISED = '2026-09-06T18:04:11.000Z'
 
 /* The whole point of this module is that a bad file cannot cost the dancer
    their loops, so every case below is about telling three things apart:
@@ -15,12 +20,16 @@ describe('reading a loops.json body', () => {
 
     expect(readLoopsFile(written({ 'shuffle-drill': [loop] }))).toEqual({
       readable: true,
-      loops: { schema: 1, clips: { 'shuffle-drill': [loop] } },
+      loops: { schema: 1, clips: { 'shuffle-drill': [loop] }, touched: {} },
     })
   })
 
   it('survives a round trip through the writer', () => {
-    const loops = { schema: 1 as const, clips: { 'shuffle-drill': [getLoop()] } }
+    const loops = {
+      schema: 1 as const,
+      clips: { 'shuffle-drill': [getLoop()] },
+      touched: {},
+    }
 
     expect(readLoopsFile(serialiseLoops(loops))).toEqual({
       readable: true,
@@ -90,7 +99,7 @@ describe('a malformed loop among good ones', () => {
       ),
     ).toEqual({
       readable: true,
-      loops: { schema: 1, clips: { 'shuffle-drill': [good] } },
+      loops: { schema: 1, clips: { 'shuffle-drill': [good] }, touched: {} },
     })
   })
 
@@ -120,7 +129,7 @@ describe('a malformed loop among good ones', () => {
       readLoopsFile(written({ broken: 'not a list', kept: [good] })),
     ).toEqual({
       readable: true,
-      loops: { schema: 1, clips: { kept: [good] } },
+      loops: { schema: 1, clips: { kept: [good] }, touched: {} },
     })
   })
 
@@ -131,5 +140,103 @@ describe('a malformed loop among good ones', () => {
       readable: true,
       loops: NO_LOOPS,
     })
+  })
+})
+
+/* When each clip was last worked on (#12), which is what the **Last practised**
+   chip orders by.
+
+   Recency is not the asset — the loops are — and every rule below follows from
+   that one asymmetry. A stamp that cannot be read is dropped; a *loop* that
+   cannot be read makes the whole file untouchable. Losing a stamp costs an
+   ordering until the next save. Losing a loop costs the dancer their work. */
+describe('when a clip was last practised', () => {
+  it('reads back the stamps beside the loops', () => {
+    const loop = getLoop()
+
+    expect(
+      readLoopsFile(
+        written({ 'shuffle-drill': [loop] }, { 'shuffle-drill': PRACTISED }),
+      ),
+    ).toEqual({
+      readable: true,
+      loops: {
+        schema: 1,
+        clips: { 'shuffle-drill': [loop] },
+        touched: { 'shuffle-drill': PRACTISED },
+      },
+    })
+  })
+
+  /* Every `loops.json` in Drive predates this, and the dancer's loops are in
+     them. Reading one as anything other than "practised nothing yet" would be
+     the feature arriving by destroying what it was built to order. */
+  it('reads a file written before stamps existed as nothing practised yet', () => {
+    const loop = getLoop()
+
+    expect(readLoopsFile(written({ 'shuffle-drill': [loop] }))).toEqual({
+      readable: true,
+      loops: { schema: 1, clips: { 'shuffle-drill': [loop] }, touched: {} },
+    })
+  })
+
+  it('survives a round trip through the writer', () => {
+    const loops = {
+      schema: 1 as const,
+      clips: { 'shuffle-drill': [getLoop()] },
+      touched: { 'shuffle-drill': PRACTISED },
+    }
+
+    expect(readLoopsFile(serialiseLoops(loops))).toEqual({
+      readable: true,
+      loops,
+    })
+  })
+
+  /* Removing a clip's last loop drops it out of `clips` and is itself an act of
+     practising it, so the stamp has to outlive the loops it was made by. */
+  it('keeps a stamp for a clip that has no loops left', () => {
+    expect(readLoopsFile(written({}, { 'shuffle-drill': PRACTISED }))).toEqual({
+      readable: true,
+      loops: { schema: 1, clips: {}, touched: { 'shuffle-drill': PRACTISED } },
+    })
+  })
+
+  it('drops a stamp that is not a string and keeps its siblings', () => {
+    expect(
+      readLoopsFile(
+        written({}, { broken: 1757181851000, kept: PRACTISED }),
+      ),
+    ).toEqual({
+      readable: true,
+      loops: { schema: 1, clips: {}, touched: { kept: PRACTISED } },
+    })
+  })
+
+  /* A string is not yet a time. This one sorts somewhere arbitrary rather than
+     failing loudly, so it is refused at the door instead. */
+  it('drops a stamp that is not a time', () => {
+    expect(
+      readLoopsFile(written({}, { broken: 'last Tuesday-ish' })),
+    ).toEqual({ readable: true, loops: NO_LOOPS })
+  })
+
+  /* The asymmetry, stated as a test: `clips` being the wrong shape refuses the
+     whole file, because the loops in it are unaccounted for. `touched` being
+     the wrong shape must not, because refusing would throw away readable loops
+     to punish a broken ordering. */
+  it('keeps the file when the stamps themselves are the wrong shape', () => {
+    const loop = getLoop()
+    const readable = {
+      readable: true,
+      loops: { schema: 1, clips: { 'shuffle-drill': [loop] }, touched: {} },
+    }
+
+    expect(readLoopsFile(written({ 'shuffle-drill': [loop] }, []))).toEqual(
+      readable,
+    )
+    expect(
+      readLoopsFile(written({ 'shuffle-drill': [loop] }, 'yesterday')),
+    ).toEqual(readable)
   })
 })

--- a/app/src/loops/loopsFile.test.ts
+++ b/app/src/loops/loopsFile.test.ts
@@ -213,6 +213,28 @@ describe('when a clip was last practised', () => {
     })
   })
 
+  /* The other half of that same argument. `Date.parse` understands far more
+     than this app writes, and a stamp carrying an offset is a time that reads
+     perfectly and still sorts wrong: `laterOf` and the chip both compare these
+     as plain strings, so `…T19:04:11+02:00` sorts *after* `…T18:00:00.000Z`
+     while being the earlier instant. The type says "always UTC" — the door is
+     where that is made true, rather than trusted.
+
+     Not hypothetical: `loops.json` is indented precisely so the dancer can open
+     it in their own Drive, and UC-01 Q-06 will read this shape back in. */
+  it('normalises a stamp that arrived in some other time zone', () => {
+    expect(
+      readLoopsFile(written({}, { 'shuffle-drill': '2026-09-06T19:04:11+02:00' })),
+    ).toEqual({
+      readable: true,
+      loops: {
+        schema: 1,
+        clips: {},
+        touched: { 'shuffle-drill': '2026-09-06T17:04:11.000Z' },
+      },
+    })
+  })
+
   /* A string is not yet a time. This one sorts somewhere arbitrary rather than
      failing loudly, so it is refused at the door instead. */
   it('drops a stamp that is not a time', () => {

--- a/app/src/loops/loopsFile.ts
+++ b/app/src/loops/loopsFile.ts
@@ -107,6 +107,16 @@ const clipsFrom = (
 const isTime = (value: unknown): value is string =>
   typeof value === 'string' && Number.isFinite(Date.parse(value))
 
+/* And a time is not yet a *comparable* one. `laterOf` and the **Last
+   practised** chip both compare these as plain strings, which only orders
+   chronologically for ISO-8601 UTC — so `…T19:04:11+02:00` would sort after
+   `…T18:00:00.000Z` while being the earlier instant. `isTime` above admits
+   every form `Date.parse` understands, so the same door that accepts a stamp
+   is where it is put in the one shape the comparisons hold for. This app only
+   ever writes `toISOString()`; the file is indented to be legible in the
+   dancer's own Drive, and UC-01 Q-06 will read this shape back in. */
+const asUtc = (at: string) => new Date(at).toISOString()
+
 /* The asymmetry that decides this whole module: `clips` being the wrong shape
    refuses the file, because loops are unaccounted for. `touched` being the wrong
    shape must not, because refusing would throw away readable loops to punish a
@@ -120,7 +130,7 @@ const touchedFrom = (held: unknown): Readonly<Record<string, string>> => {
 
   return Object.fromEntries(
     Object.entries(held).flatMap<[string, string]>(([clipId, at]) =>
-      isTime(at) ? [[clipId, at]] : [],
+      isTime(at) ? [[clipId, asUtc(at)]] : [],
     ),
   )
 }

--- a/app/src/loops/loopsFile.ts
+++ b/app/src/loops/loopsFile.ts
@@ -10,15 +10,38 @@ import type { SavedLoop } from './loop'
 
    `schema` is one field of insurance. The loops are the asset, UC-01 Q-06 will
    export this exact shape, and a reader that meets a version it does not know
-   should say so rather than mangle what it found. */
+   should say so rather than mangle what it found.
+
+   **It stays at 1 as the shape grows, and `touched` (#12) is the precedent.**
+   The version is not a changelog — it is the switch that makes a reader refuse
+   the file, and refusing is only ever right when the loops themselves are at
+   stake. Bumping it for an added field would tell every device still on an
+   older deployed build that the file is unreadable, and that device would then
+   stop saving. Left at 1, the same device ignores the key it does not know and
+   drops it on its next write: recency lost, never a loop. Bump it only for a
+   change that would make an old reader mangle the loops. */
 export const SCHEMA = 1
 
 export type LoopsFile = {
   readonly schema: typeof SCHEMA
   readonly clips: Readonly<Record<string, readonly SavedLoop[]>>
+  /* When each clip was last worked on — the last time a loop was saved on it or
+     removed from it (#12), which is what the **Last practised** chip orders by.
+     ISO-8601, always UTC, because that is the one format whose string order is
+     its time order and the merge below compares them as strings.
+
+     A sibling of `clips` rather than a field on each loop: it is a fact about
+     the clip, and the clip it belongs to may have no loops left. Keyed the same
+     way, so both maps survive a re-upload for the same reason.
+
+     Always present, empty when nothing has been practised, exactly as `clips`
+     is — the "not carried around forever" rule (`withClip`) is about entries,
+     not about the map. That keeps `LoopsFile` a total shape and spares every
+     reader a `?? {}`. */
+  readonly touched: Readonly<Record<string, string>>
 }
 
-export const NO_LOOPS: LoopsFile = { schema: SCHEMA, clips: {} }
+export const NO_LOOPS: LoopsFile = { schema: SCHEMA, clips: {}, touched: {} }
 
 /* Three answers, not two, and the third is the one that matters: a file this
    app cannot understand is refused rather than read as empty, because reading
@@ -78,6 +101,30 @@ const clipsFrom = (
     ),
   )
 
+/* A string is not yet a time. An unparseable one would sort somewhere arbitrary
+   rather than fail, so it is refused at the door — the same argument `isNumber`
+   above makes about `NaN` reaching a seek. */
+const isTime = (value: unknown): value is string =>
+  typeof value === 'string' && Number.isFinite(Date.parse(value))
+
+/* The asymmetry that decides this whole module: `clips` being the wrong shape
+   refuses the file, because loops are unaccounted for. `touched` being the wrong
+   shape must not, because refusing would throw away readable loops to punish a
+   broken ordering — and an ordering costs nothing to rebuild, since the next
+   save stamps the clip again.
+
+   So everything here degrades: a map that is not a map reads as no stamps, and
+   a stamp that is not a time is dropped on its own, leaving its siblings. */
+const touchedFrom = (held: unknown): Readonly<Record<string, string>> => {
+  if (!isRecord(held)) return {}
+
+  return Object.fromEntries(
+    Object.entries(held).flatMap<[string, string]>(([clipId, at]) =>
+      isTime(at) ? [[clipId, at]] : [],
+    ),
+  )
+}
+
 const parsed = (body: string): unknown => {
   try {
     return JSON.parse(body) as unknown
@@ -103,7 +150,14 @@ export const readLoopsFile = (body: string): LoopsRead => {
 
   return {
     readable: true,
-    loops: { schema: SCHEMA, clips: clipsFrom(held.clips) },
+    loops: {
+      schema: SCHEMA,
+      clips: clipsFrom(held.clips),
+      /* Absent on every file written before #12, which `touchedFrom` reads as
+         no stamps rather than as a reason to refuse. That is what lets this
+         land without a schema bump — see the note on `SCHEMA`. */
+      touched: touchedFrom(held.touched),
+    },
   }
 }
 

--- a/app/src/loops/loopsHandle.factory.ts
+++ b/app/src/loops/loopsHandle.factory.ts
@@ -56,15 +56,24 @@ export const useFakeLoops = ({
     [held, refuses],
   )
 
+  /* A real clock, as `useLoops` uses — the fake is standing in for Drive, not
+     for time, and a frozen stamp would let a test pass that the real hook
+     fails. */
   const save = useCallback(
-    (clipId: string, loop: SavedLoop) =>
-      write((current) => withLoop(current, clipId, loop)),
+    (clipId: string, loop: SavedLoop) => {
+      const at = new Date().toISOString()
+
+      return write((current) => withLoop(current, clipId, loop, at))
+    },
     [write],
   )
 
   const remove = useCallback(
-    (clipId: string, id: string) =>
-      write((current) => withoutLoop(current, clipId, id)),
+    (clipId: string, id: string) => {
+      const at = new Date().toISOString()
+
+      return write((current) => withoutLoop(current, clipId, id, at))
+    },
     [write],
   )
 

--- a/app/src/loops/useLoops.test.tsx
+++ b/app/src/loops/useLoops.test.tsx
@@ -181,19 +181,22 @@ describe('saving a loop', () => {
   it('refreshes the local copy with what was written', async () => {
     const loop = getLoop()
     const cache = aLoopsCache()
+    const api = holding({})
 
-    const { result } = renderLoops(holding({}), { cache })
+    const { result } = renderLoops(api, { cache })
 
     await result.current.save(A_CLIP, loop)
 
-    expect(cache.write).toHaveBeenCalledWith({
-      ...NO_LOOPS,
-      clips: { [A_CLIP]: [loop] },
-      /* Whatever the clock said. That the stamp is *the time of the save* is
-         pinned below, under a frozen one; this test is about the local copy
-         matching what went to Drive. */
-      touched: { [A_CLIP]: expect.any(String) as unknown as string },
-    })
+    const written = bodyWritten(api)
+
+    /* Against the body itself rather than against a shape restated here with
+       the stamp loosened to "some string". The claim is that the two agree —
+       comparing them directly says that, holds the stamp to the same standard
+       as everything beside it, and needs no assertion to get past the clock.
+       That the stamp is *the time of the save* is pinned below, under a frozen
+       one. */
+    expect(written.clips).toEqual({ [A_CLIP]: [loop] })
+    expect(cache.write).toHaveBeenCalledWith(written)
   })
 
   /* The criterion the whole story turns on: a loop silently lost is the worst

--- a/app/src/loops/useLoops.test.tsx
+++ b/app/src/loops/useLoops.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DriveApi } from '../drive/driveApi'
 import { DriveError } from '../drive/driveApi'
@@ -11,6 +11,7 @@ import type { TokenStore } from '../drive/tokenStore'
 import { getLoop } from './loop.factory'
 import type { LoopsCache } from './loopsCache'
 import { aLoopsCache } from './loopsCache.factory'
+import type { LoopsFile } from './loopsFile'
 import { NO_LOOPS, serialiseLoops } from './loopsFile'
 import { useLoops } from './useLoops'
 
@@ -44,6 +45,13 @@ const holding = (clips: Record<string, readonly ReturnType<typeof getLoop>[]>) =
     findJson: vi.fn(async () => ({ id: A_LOOPS_FILE, version: '3' })),
     readJson: vi.fn(async () => serialiseLoops({ ...NO_LOOPS, clips })),
   })
+
+/* The last body this hook actually put in Drive, parsed back. What was written
+   is the claim worth making — the hook's own state is downstream of it. */
+const bodyWritten = (api: DriveApi) =>
+  JSON.parse(
+    String(vi.mocked(api.writeJson).mock.calls.at(-1)?.[2]),
+  ) as LoopsFile
 
 const renderLoops = (
   api: DriveApi,
@@ -181,6 +189,10 @@ describe('saving a loop', () => {
     expect(cache.write).toHaveBeenCalledWith({
       ...NO_LOOPS,
       clips: { [A_CLIP]: [loop] },
+      /* Whatever the clock said. That the stamp is *the time of the save* is
+         pinned below, under a frozen one; this test is about the local copy
+         matching what went to Drive. */
+      touched: { [A_CLIP]: expect.any(String) as unknown as string },
     })
   })
 
@@ -308,5 +320,62 @@ describe('removing a loop', () => {
       expect(result.current.notice).not.toBeNull()
     })
     expect(result.current.loops.clips).toEqual({ [A_CLIP]: [loop] })
+  })
+})
+
+/* #12 — this is the hook's only share of the feature: it is where the clock is
+   read. What the stamp *means* once it exists is `loopsChange.test.ts`.
+
+   The write that carries it is the write that was already happening, which is
+   the whole design: the failure criterion above ("a write that did not land
+   adds nothing") extends to recency for free, because there is no second call
+   that could leave Drive claiming a clip was practised while the loop that was
+   practised on it never arrived. */
+describe('stamping the clip as practised', () => {
+  const PRACTISED = '2026-09-06T18:04:11.000Z'
+
+  beforeEach(() => {
+    /* `shouldAdvanceTime`, so the promises inside a save still settle — the
+       clock is being pinned to a known reading, not stopped. */
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(PRACTISED))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends the stamp to Drive in the same body as the loop', async () => {
+    const loop = getLoop()
+    const api = holding({})
+
+    const { result } = renderLoops(api)
+
+    await result.current.save(A_CLIP, loop)
+
+    expect(bodyWritten(api)).toEqual({
+      ...NO_LOOPS,
+      clips: { [A_CLIP]: [loop] },
+      touched: { [A_CLIP]: PRACTISED },
+    })
+  })
+
+  it('stamps a removal as readily as a save', async () => {
+    const api = holding({ [A_CLIP]: [getLoop({ id: 'going' })] })
+
+    const { result } = renderLoops(api)
+
+    await waitFor(() => {
+      expect(result.current.loops.clips[A_CLIP]).toHaveLength(1)
+    })
+
+    /* Re-pinned here rather than only in `beforeEach`: the clock advances with
+       real time so the wait above can finish, and what is being asserted is the
+       reading at the moment of the removal. */
+    vi.setSystemTime(new Date(PRACTISED))
+
+    await result.current.remove(A_CLIP, 'going')
+
+    expect(bodyWritten(api).touched).toEqual({ [A_CLIP]: PRACTISED })
   })
 })

--- a/app/src/loops/useLoops.ts
+++ b/app/src/loops/useLoops.ts
@@ -28,6 +28,17 @@ export type LoopsHandle = {
   readonly remove: (clipId: string, id: string) => Promise<boolean>
 }
 
+/* The moment the dancer pressed the button, which is what `touched` records
+   (#12). Taken here, once, rather than inside the change handed to
+   `applyToLoops`: that change may be replayed on a retry, and the stamp is
+   about what the dancer did rather than which attempt happened to land. Keeping
+   the clock out of it also keeps `LoopsChange` a pure function of the file,
+   which is what makes the merge replayable in the first place.
+
+   UTC, because `touched` is compared as a string and only this format sorts
+   chronologically when it is. */
+const practisedNow = () => new Date().toISOString()
+
 /* Deliberately different sentences, because the dancer can act on the
    difference. "Could not be read" also carries the news that their existing
    loops are still there, in a file this app has refused to touch — reporting
@@ -165,8 +176,11 @@ export const useLoops = (
   )
 
   const save = useCallback(
-    (clipId: string, loop: SavedLoop) =>
-      write((held) => withLoop(held, clipId, loop), `“${loop.name}”`),
+    (clipId: string, loop: SavedLoop) => {
+      const at = practisedNow()
+
+      return write((held) => withLoop(held, clipId, loop, at), `“${loop.name}”`)
+    },
     [write],
   )
 
@@ -174,8 +188,11 @@ export const useLoops = (
      to is still on screen when the sentence appears — the dancer can see which
      one it is, and a name repeated back adds nothing. */
   const remove = useCallback(
-    (clipId: string, id: string) =>
-      write((held) => withoutLoop(held, clipId, id), 'That removal'),
+    (clipId: string, id: string) => {
+      const at = practisedNow()
+
+      return write((held) => withoutLoop(held, clipId, id, at), 'That removal')
+    },
     [write],
   )
 

--- a/mockup/src/App.jsx
+++ b/mockup/src/App.jsx
@@ -5,7 +5,15 @@ import Player from './Player.jsx'
 /* Stand-in for what Drive will return. Only the first entry is a real clip —
    the rest are deliberately blank placeholders, so the grid reads as a list of
    separate clips rather than one clip chopped into pieces. The loops belonging
-   to a clip live on the player screen; here they are only a count. */
+   to a clip live on the player screen; here they are only a count.
+
+   `practised` is when a loop was last saved on the clip or removed from it
+   (#12) — seeded rather than produced, because this player keeps its saved
+   loops to itself and never tells the list about them. The values run counter
+   to both `added` and `loops` on purpose: the clip added most recently was last
+   worked on a week ago, and two clips have never been worked on at all. That is
+   the whole argument for the chip, and it is only visible in data that
+   disagrees with the other three. */
 const SEED_CLIPS = [
   {
     id: 1,
@@ -13,12 +21,34 @@ const SEED_CLIPS = [
     added: '2026-08-29',
     seconds: 26,
     loops: 5,
+    practised: '2026-08-30T11:20:00.000Z',
     src: '/sample.mp4',
   },
-  { id: 2, name: 'Clip 2', added: '2026-08-27', seconds: 18, loops: 2 },
+  {
+    id: 2,
+    name: 'Clip 2',
+    added: '2026-08-27',
+    seconds: 18,
+    loops: 2,
+    practised: '2026-09-06T18:04:11.000Z',
+  },
   { id: 3, name: 'Clip 3', added: '2026-08-24', seconds: 41, loops: 0 },
-  { id: 4, name: 'Clip 4', added: '2026-08-19', seconds: 12, loops: 3 },
-  { id: 5, name: 'Clip 5', added: '2026-08-11', seconds: 33, loops: 1 },
+  {
+    id: 4,
+    name: 'Clip 4',
+    added: '2026-08-19',
+    seconds: 12,
+    loops: 3,
+    practised: '2026-09-05T20:00:00.000Z',
+  },
+  {
+    id: 5,
+    name: 'Clip 5',
+    added: '2026-08-11',
+    seconds: 33,
+    loops: 1,
+    practised: '2026-08-12T09:15:00.000Z',
+  },
   { id: 6, name: 'Clip 6', added: '2026-08-04', seconds: 24, loops: 0 },
 ]
 

--- a/mockup/src/Library.jsx
+++ b/mockup/src/Library.jsx
@@ -1,9 +1,25 @@
 import { useEffect, useRef, useState } from 'react'
 
+/* Retrofitted from the product (#12) — the mockup gate pass for a chip that was
+   built before anything had drawn it.
+
+   Recent is the day a clip was uploaded and never changes again, so it cannot
+   answer "what am I working on". Last practised can. A clip never practised
+   compares as the empty string, which puts the whole never-practised tail below
+   every clip that has been — and still draws it, because a clip vanishing from
+   the grid under one chip would read as a clip deleted.
+
+   Last of the four so that `SORTS[0]` stays Recent: it is the default, and it
+   is where the grid jumps back to after an add. */
 const SORTS = [
   { id: 'added', label: 'Recent', compare: (a, b) => b.added.localeCompare(a.added) },
   { id: 'name', label: 'Name', compare: (a, b) => a.name.localeCompare(b.name) },
   { id: 'loops', label: 'Most looped', compare: (a, b) => b.loops - a.loops },
+  {
+    id: 'practised',
+    label: 'Last practised',
+    compare: (a, b) => (b.practised ?? '').localeCompare(a.practised ?? ''),
+  },
 ]
 
 function formatDuration(seconds) {


### PR DESCRIPTION
Closes #12.

A fourth chip on the clips grid, ordering by when each clip was last worked
on. **Recent** is the day a clip was uploaded and never changes again, so a
clip added in July and drilled last night sorts below six that were added and
never opened. This is the chip that answers "what am I working on".

## What counts as practising

The last time a loop was **saved on** the clip or **removed from** it. Those
are the two moments `loops.json` is already being written, so recency costs no
new Drive call and adds no new failure path. Opening a clip in the player
deliberately does not count — that would need a write per open.

## The data

`loops.json` gains a `touched` map, a sibling of `clips`, keyed on the same
`clip.id`:

```json
{
  "schema": 1,
  "clips":   { "added-basic-step-9421-1756…": [ … ] },
  "touched": { "added-basic-step-9421-1756…": "2026-09-06T18:04:11.000Z" }
}
```

Three decisions worth reviewing, each one falling out of how the file already
works:

- **`schema` stays at 1.** The version is not a changelog — it is the switch
  that makes `readLoopsFile` refuse the file, and refusing is only ever right
  when the loops themselves are at stake. Bumping it would tell every device
  still on an older deployed build that the file is unreadable, and that device
  would then stop saving. Left at 1, the same device ignores the key it does not
  know and drops it on its next write: recency lost, never a loop.
- **The reader degrades where `clips` refuses.** A `touched` that is not a map
  reads as no stamps; a stamp that is not a parseable time is dropped on its own
  and its siblings stand. Recency is not the asset — throwing away readable
  loops to punish a broken ordering would be the wrong way round.
- **`max(held, at)` on merge, not assignment.** `applyToLoops` replays the
  change onto whatever Drive holds *now*, so a stamp captured before that round
  trip can land on top of a newer one the phone already wrote. Assigning would
  let a laptop that has been offline drag a clip's recency backwards. ISO-8601
  UTC is what makes that a string comparison.

`at` is passed into the change rather than read from a clock inside it, so
`LoopsChange` stays a pure function of the file — that purity is what makes
replaying it a complete merge — and so the stamp records the moment the dancer
pressed the button rather than the moment a retry happened to run.

## Falls out for free

The failure criterion already covering loops now covers recency. The stamp is
in the same body as the loops, so there is no second write that could leave
Drive claiming a clip was practised while the loop practised on it never
arrived.

## Acceptance criteria

All ten from #12 are covered by tests, including the never-practised tail
sorting last while still being drawn, a pre-#12 `loops.json` reading with every
loop intact, and the later-timestamp-wins merge.

## Verification

`node scripts/verify.mjs` — **GATE: PASS**, 7 checks ran, all green; 5 skipped
(the skips are pre-existing: no `test` or `typecheck` script in `mockup`, and no
`build`/`lint`/`typecheck` at the root).

Not yet driven against real Drive — the smoke test is the reviewer's first step.
Worth watching for: save a loop on an old clip, return to the grid, pick **Last
practised**, and confirm both that the clip is now first and that `loops.json`
in Drive has grown a `touched` key with every existing loop still there.

## Mockup gate pass

`mockup/src/Library.jsx` gains the same fourth pill and the seed clips gain a
`practised` date, so the mockup stays a true reference for UC-01 rather than a
stale one. Seeded rather than produced: that player keeps its saved loops to
itself and never tells the list about them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gZfpvFyvGK93DkmjYVuBS
