### PR TITLE
Order the clips grid by when each clip was last opened

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -30,6 +30,8 @@ import type { TokenSource } from './drive/gisTokenSource'
 import type { TokenStore } from './drive/tokenStore'
 import type { SavedLoop } from './loops/loop'
 import { getLoop } from './loops/loop.factory'
+import { localOpenedStore } from './clips/openedStore'
+import { inMemoryStorage } from './drive/keyValueStorage.factory'
 import { aLoopsCache } from './loops/loopsCache.factory'
 import { NO_LOOPS, serialiseLoops } from './loops/loopsFile'
 import { inDocumentOrder } from './test/documentOrder'
@@ -148,7 +150,11 @@ const renderAppAt = (
   path: string,
   tokenSource: TokenSource = sourceGranting(),
   extras: ReactNode = null,
-  { tokenStore = aTokenStore(), driveApi = driveHolding() } = {},
+  {
+    tokenStore = aTokenStore(),
+    driveApi = driveHolding(),
+    openedStore = localOpenedStore(inMemoryStorage()),
+  } = {},
 ) =>
   render(
     <DriveSessionProvider tokenSource={tokenSource} tokenStore={tokenStore}>
@@ -157,6 +163,7 @@ const renderAppAt = (
           driveApi={driveApi}
           clipCache={holdsNothing}
           loopsCache={aLoopsCache()}
+          openedStore={openedStore}
         />
         {extras}
       </MemoryRouter>
@@ -954,5 +961,127 @@ describe('the still a clip is remembered by', () => {
       expect(tileCount()).toBe(1)
     })
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})
+
+/* #16 — the fourth chip. What it orders by is the last time the dancer opened
+   the clip, which is the action a practice session is mostly made of; the
+   **Last practised** chip it replaces moved only when a loop was saved or
+   removed, which is rare enough that the ordering seldom changed. */
+describe('ordering the grid by when each clip was last opened', () => {
+  const THREE_CLIPS = [
+    getClip({ id: 'newest', name: 'Newest', added: '2026-09-04' }),
+    getClip({ id: 'middle', name: 'Middle', added: '2026-08-20' }),
+    getClip({ id: 'oldest', name: 'Oldest', added: '2026-08-02' }),
+  ]
+
+  const renderGrid = (openedStore = localOpenedStore(inMemoryStorage())) =>
+    renderAppAt('/', sourceGranting(), null, {
+      tokenStore: aConnectedStore(),
+      driveApi: driveHolding(THREE_CLIPS),
+      openedStore,
+    })
+
+  const gridOrder = () =>
+    within(screen.getByRole('list', { name: 'Clips' }))
+      .getAllByRole('link')
+      .map((link) => link.getAttribute('href')?.replace('/clip/', ''))
+
+  const chip = () => screen.getByRole('button', { name: 'Last opened' })
+
+  const openAndReturn = async (name: string) => {
+    await userEvent.click(await screen.findByText(name))
+    await userEvent.click(
+      await screen.findByRole('link', { name: 'Back to clips' }),
+    )
+  }
+
+  it('offers the chip in place of Last practised', async () => {
+    renderGrid()
+    await screen.findByText('Newest')
+
+    expect(chip()).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Last practised' }),
+    ).not.toBeInTheDocument()
+  })
+
+  /* The whole feature in one case: open a clip, come back, and it is top. */
+  it('puts the clip just opened at the front', async () => {
+    renderGrid()
+    await screen.findByText('Newest')
+    await userEvent.click(chip())
+
+    await openAndReturn('Oldest')
+
+    expect(gridOrder()[0]).toBe('oldest')
+  })
+
+  it('puts the one opened before it second', async () => {
+    renderGrid()
+    await screen.findByText('Newest')
+    await userEvent.click(chip())
+
+    await openAndReturn('Oldest')
+    await openAndReturn('Middle')
+
+    expect(gridOrder().slice(0, 2)).toEqual(['middle', 'oldest'])
+  })
+
+  /* Found by driving the mockup. The grid is unmounted while the player is up,
+     so an ordering held on the screen itself started over at Recent on every
+     return — which is the one moment this chip exists to be looked at. */
+  it('is still the chosen ordering after a trip through the player', async () => {
+    renderGrid()
+    await screen.findByText('Newest')
+    await userEvent.click(chip())
+
+    await openAndReturn('Oldest')
+
+    expect(chip()).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('sorts a clip never opened below every clip that has been, and draws it', async () => {
+    renderGrid()
+    await screen.findByText('Newest')
+    await userEvent.click(chip())
+
+    await openAndReturn('Oldest')
+
+    expect(gridOrder()).toHaveLength(3)
+    expect(gridOrder()[0]).toBe('oldest')
+  })
+
+  /* The reason the stamp is kept on the device: an open costs Drive nothing.
+     `loops.json` holds the loops, and writing it dozens of times a session for
+     an ordering would put the asset in the path of an action worth nothing. */
+  it('writes nothing to Drive when a clip is merely opened', async () => {
+    const driveApi = driveHolding(THREE_CLIPS)
+
+    renderAppAt('/', sourceGranting(), null, {
+      tokenStore: aConnectedStore(),
+      driveApi,
+    })
+    await screen.findByText('Newest')
+
+    await openAndReturn('Oldest')
+
+    expect(driveApi.writeJson).not.toHaveBeenCalled()
+    expect(driveApi.createJson).not.toHaveBeenCalled()
+  })
+
+  /* Kept across a reload, which a phone gives you for free when it reclaims the
+     tab — so the store is read back rather than the ordering starting over. */
+  it('remembers what was opened on an earlier visit', async () => {
+    const storage = inMemoryStorage()
+
+    renderGrid(localOpenedStore(storage))
+    await screen.findByText('Newest')
+    await userEvent.click(chip())
+    await openAndReturn('Oldest')
+
+    /* Read back through a *second* store over the same storage, which is what a
+       reload is: nothing of the first one's state survives it. */
+    expect(localOpenedStore(storage).read()).toHaveProperty('oldest')
   })
 })

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { Route, Routes } from 'react-router'
 
 import type { Clip } from './clips/clip'
@@ -7,14 +7,18 @@ import { browserClipCache, browserThumbnailCache } from './clips/clipCache'
 import type { ClipProbe } from './clips/clipProbe'
 import { browserClipProbe } from './clips/clipProbe'
 import { ClipsScreen } from './clips/ClipsScreen'
-import { withLoopCounts, withPractised } from './clips/library'
+import { withLoopCounts, withOpened } from './clips/library'
+import type { OpenedStore } from './clips/openedStore'
+import { browserOpenedStore } from './clips/openedStore'
+import type { OrderingId } from './clips/ordering'
+import { orderings } from './clips/ordering'
 import type { ThumbnailCapture } from './clips/thumbnail'
 import { browserThumbnailCapture } from './clips/thumbnail'
 import { useLibrary } from './clips/useLibrary'
 import { useThumbnails } from './clips/useThumbnails'
 import type { DriveApi } from './drive/driveApi'
 import { browserDriveApi } from './drive/driveApi'
-import { countOf, practisedAt } from './loops/loopsChange'
+import { countOf, laterOf, openedAt } from './loops/loopsChange'
 import type { LoopsCache } from './loops/loopsCache'
 import { browserLoopsCache } from './loops/loopsCache'
 import { useLoops } from './loops/useLoops'
@@ -33,6 +37,7 @@ export function App({
   driveApi = browserDriveApi,
   clipCache = browserClipCache,
   loopsCache = browserLoopsCache,
+  openedStore = browserOpenedStore,
   thumbnailCache = browserThumbnailCache,
   capture = browserThumbnailCapture,
 }: {
@@ -40,6 +45,7 @@ export function App({
   readonly driveApi?: DriveApi
   readonly clipCache?: ClipCache
   readonly loopsCache?: LoopsCache
+  readonly openedStore?: OpenedStore
   readonly thumbnailCache?: ThumbnailCache
   readonly capture?: ThumbnailCapture
 } = {}) {
@@ -53,14 +59,43 @@ export function App({
      read them: the player lists a clip's loops, and the Clips screen puts the
      count in each tile and orders by it under **Most looped**. One `loops.json`
      holds every clip's, so there is one place to read it from (US-01-15). */
-  const loops = useLoops(driveApi, loopsCache)
-  /* The clips as the grid draws them: counts, and when each was last practised
+  /* When this device opened each clip (#16). In state as well as in storage so
+     the grid re-orders the moment the dancer comes back from the player, rather
+     than on the next reload. */
+  const [opened, setOpened] = useState(() => openedStore.read())
+
+  const markOpened = useCallback(
+    (clipId: string) => {
+      const at = new Date().toISOString()
+
+      openedStore.stamp(clipId, at)
+      setOpened((held) => ({ ...held, [clipId]: at }))
+    },
+    [openedStore],
+  )
+
+  /* A getter, so the write carries what this device knows at the moment it
+     runs. Opening a clip never writes to Drive itself — these stamps ride the
+     write a loop save or removal was already making. */
+  const opensNow = useCallback(() => opened, [opened])
+
+  const loops = useLoops(driveApi, loopsCache, opensNow)
+
+  /* Which chip is active, held here rather than on the Clips screen because
+     that screen is unmounted while the player is up — and **Last opened** is
+     the chip you pick before opening a clip and want to still be on when you
+     come back. */
+  const [ordering, setOrdering] = useState<OrderingId>(orderings[0].id)
+  /* The clips as the grid draws them: counts, and when each was last opened
      (#12). All of it arrives separately — Drive's file listing knows nothing
      about loops, and `loops.json` is fetched on its own — so this is where they
      are put together, once, for both screens. */
-  const counted = withPractised(
+  const counted = withOpened(
     withLoopCounts(library, (clipId) => countOf(loops.loops, clipId)),
-    (clipId) => practisedAt(loops.loops, clipId),
+    /* This device's own record and Drive's may each be ahead of the other — a
+       phone that opened it this morning, a laptop that opened it last week and
+       has not written since — so the honest answer is the later of the two. */
+    (clipId) => laterOf(opened[clipId], openedAt(loops.loops, clipId)),
   )
   /* Beside the loops, and above both routes for the same reason: the grid
      paints the stills and the player makes the ones that are missing, so a
@@ -116,6 +151,8 @@ export function App({
         element={
           <ClipsScreen
             library={counted}
+            ordering={ordering}
+            onOrderingChange={setOrdering}
             thumbnails={stills}
             onAdd={onAdd}
             onDelete={onDelete}
@@ -133,6 +170,7 @@ export function App({
             driveApi={driveApi}
             clipCache={clipCache}
             onBytes={onClipBytes}
+            onOpened={markOpened}
             stillLoading={library.state === 'loading'}
           />
         }

--- a/app/src/clips/ClipsLibrary.test.tsx
+++ b/app/src/clips/ClipsLibrary.test.tsx
@@ -10,6 +10,7 @@ import type { ClipProbe } from './clipProbe'
 import { ClipsScreen } from './ClipsScreen'
 import type { Library } from './library'
 import { adding, failed, LOADING, loaded } from './library'
+import { orderings } from './ordering'
 
 const anUnconfiguredDrive: TokenSource = async () => ({
   ok: false,
@@ -23,6 +24,7 @@ const anEmptyTokenStore: TokenStore = {
 }
 
 const noClipIsAdded = () => {}
+const noOrderingIsChosen = () => {}
 const noFileIsProbed: ClipProbe = async () => ({ ok: false })
 const noClipIsDeleted = () => {}
 
@@ -35,6 +37,8 @@ const renderLibrary = (library: Library) =>
       <MemoryRouter>
         <ClipsScreen
           library={library}
+          ordering={orderings[0].id}
+          onOrderingChange={noOrderingIsChosen}
           onAdd={noClipIsAdded}
           onDelete={noClipIsDeleted}
           probe={noFileIsProbed}

--- a/app/src/clips/ClipsScreen.test.tsx
+++ b/app/src/clips/ClipsScreen.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
+import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { DriveSessionProvider } from '../drive/DriveSessionProvider'
@@ -10,6 +11,8 @@ import type { Clip } from './clip'
 import { getClip } from './clip.factory'
 import type { ClipProbe } from './clipProbe'
 import { ClipsScreen } from './ClipsScreen'
+import type { OrderingId } from './ordering'
+import { orderings } from './ordering'
 import { LOADING, loaded } from './library'
 
 /* The screen carries the Drive status footer (US-01-13), and the session
@@ -33,6 +36,31 @@ const noClipIsAdded = () => {}
 const noFileIsProbed: ClipProbe = async () => ({ ok: false })
 const noClipIsDeleted = () => {}
 
+/* The ordering belongs to the caller now (#16), because the real one has to
+   outlive this screen being unmounted for the player. Here the caller is this
+   wrapper, so the chips still switch for real and the cases below are unchanged
+   by the move. */
+function ScreenUnderTest({
+  clips,
+  onDelete,
+}: {
+  readonly clips: readonly Clip[]
+  readonly onDelete: (clip: Clip) => void
+}) {
+  const [ordering, setOrdering] = useState<OrderingId>(orderings[0].id)
+
+  return (
+    <ClipsScreen
+      library={loaded(LOADING, clips)}
+      ordering={ordering}
+      onOrderingChange={setOrdering}
+      onAdd={noClipIsAdded}
+      onDelete={onDelete}
+      probe={noFileIsProbed}
+    />
+  )
+}
+
 const renderScreen = (
   clips: readonly Clip[],
   onDelete: (clip: Clip) => void = noClipIsDeleted,
@@ -43,12 +71,7 @@ const renderScreen = (
       tokenStore={anEmptyTokenStore}
     >
       <MemoryRouter>
-        <ClipsScreen
-          library={loaded(LOADING, clips)}
-          onAdd={noClipIsAdded}
-          onDelete={onDelete}
-          probe={noFileIsProbed}
-        />
+        <ScreenUnderTest clips={clips} onDelete={onDelete} />
       </MemoryRouter>
     </DriveSessionProvider>,
   )
@@ -226,7 +249,7 @@ describe('the ordering chips', () => {
       'Recent',
       'Name',
       'Most looped',
-      'Last practised',
+      'Last opened',
     ])
   })
 
@@ -310,44 +333,44 @@ describe('the ordering chips', () => {
   /* #12. **Recent** is the day a clip was uploaded and never changes again, so
      a clip added in July and drilled last night sorts below six that were added
      and never opened. This is the chip that answers "what am I working on". */
-  it('draws the most recently practised clip first when Last practised is chosen', async () => {
+  it('draws the most recently opened clip first when Last opened is chosen', async () => {
     renderScreen([
-      getClip({ id: 'yesterday', practised: '2026-09-05T20:00:00.000Z' }),
-      getClip({ id: 'just-now', practised: '2026-09-06T18:04:11.000Z' }),
-      getClip({ id: 'last-week', practised: '2026-08-30T09:15:00.000Z' }),
+      getClip({ id: 'yesterday', opened: '2026-09-05T20:00:00.000Z' }),
+      getClip({ id: 'just-now', opened: '2026-09-06T18:04:11.000Z' }),
+      getClip({ id: 'last-week', opened: '2026-08-30T09:15:00.000Z' }),
     ])
 
-    await userEvent.click(screen.getByRole('button', { name: 'Last practised' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Last opened' }))
 
     expect(gridOrder()).toEqual(['just-now', 'yesterday', 'last-week'])
   })
 
   /* Most of a real library, and both halves of this matter. They sort last,
-     because never practised is not practised at the beginning of time. And they
+     because never opened is not opened at the beginning of time. And they
      are still drawn — a clip that fell out of the grid under one chip would
      read as a clip that had been deleted. */
-  it('sorts the never-practised below every clip that has been, and draws them all', async () => {
+  it('sorts the never-opened below every clip that has been, and draws them all', async () => {
     renderScreen([
       getClip({ id: 'never' }),
-      getClip({ id: 'worked-on', practised: '2026-08-30T09:15:00.000Z' }),
+      getClip({ id: 'worked-on', opened: '2026-08-30T09:15:00.000Z' }),
       getClip({ id: 'never-either' }),
     ])
 
-    await userEvent.click(screen.getByRole('button', { name: 'Last practised' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Last opened' }))
 
     expect(gridOrder()).toEqual(['worked-on', 'never', 'never-either'])
   })
 
-  it('leaves clips practised at the same moment in the order they arrived', async () => {
+  it('leaves clips opened at the same moment in the order they arrived', async () => {
     const at = '2026-09-06T18:04:11.000Z'
 
     renderScreen([
-      getClip({ id: 'first', practised: at, name: 'Camel walk' }),
-      getClip({ id: 'second', practised: at, name: 'Body roll' }),
-      getClip({ id: 'third', practised: at, name: 'Arm wave' }),
+      getClip({ id: 'first', opened: at, name: 'Camel walk' }),
+      getClip({ id: 'second', opened: at, name: 'Body roll' }),
+      getClip({ id: 'third', opened: at, name: 'Arm wave' }),
     ])
 
-    await userEvent.click(screen.getByRole('button', { name: 'Last practised' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Last opened' }))
 
     expect(gridOrder()).toEqual(['first', 'second', 'third'])
   })

--- a/app/src/clips/ClipsScreen.tsx
+++ b/app/src/clips/ClipsScreen.tsx
@@ -18,6 +18,8 @@ const RECENT: OrderingId = 'added'
 
 export function ClipsScreen({
   library,
+  ordering: chosen,
+  onOrderingChange: setChosen,
   thumbnails = {},
   onAdd,
   onDelete,
@@ -25,6 +27,13 @@ export function ClipsScreen({
   notice: driveNotice = null,
 }: {
   readonly library: Library
+  /* Held by the caller rather than here, and that is load-bearing for #16
+     rather than tidiness: this screen is unmounted while the player is up, so
+     local state would start over at Recent every time the dancer came back —
+     and **Last opened** is the chip whose whole point is what you see *after* a
+     trip through the player. */
+  readonly ordering: OrderingId
+  readonly onOrderingChange: (id: OrderingId) => void
   /* A url per clip that has a still (#77). Absent entries are clips with
      none, which paint the placeholder they always did. */
   readonly thumbnails?: Readonly<Record<string, string>>
@@ -40,7 +49,6 @@ export function ClipsScreen({
   readonly notice?: string | null
 }) {
   const { clips } = library
-  const [chosen, setChosen] = useState<OrderingId>(orderings[0].id)
   const [ownNotice, setNotice] = useState<string | null>(null)
 
   const notice = ownNotice ?? driveNotice

--- a/app/src/clips/clip.ts
+++ b/app/src/clips/clip.ts
@@ -7,14 +7,14 @@ export type Clip = {
   readonly seconds?: number | undefined
   readonly loops: number
   /* When a loop was last saved on this clip or removed from it (#12), which is
-     what the **Last practised** chip orders by. Comes from `loops.json` beside
+     what the **Last opened** chip orders by. Comes from `loops.json` beside
      the count above, and is undefined for the same two different reasons: the
      dancer has never worked on this clip, or the file has not arrived yet.
 
-     Undefined rather than a fallback date, deliberately. "Never practised" is
-     not "practised at the beginning of time" — the chip sorts it below every
+     Undefined rather than a fallback date, deliberately. "Never opened" is
+     not "opened at the beginning of time" — the chip sorts it below every
      clip that has been, and any real date would let it tie with one. */
-  readonly practised?: string | undefined
+  readonly opened?: string | undefined
   readonly src?: string | undefined
   /* Drive's own id for the file holding this clip's bytes, which is what a
      download is addressed by. Absent until the upload finishes — and absent

--- a/app/src/clips/library.test.ts
+++ b/app/src/clips/library.test.ts
@@ -8,7 +8,7 @@ import {
   LOADING,
   loaded,
   withLoopCounts,
-  withPractised,
+  withOpened,
 } from './library'
 
 describe('what the library knows before it knows anything', () => {
@@ -140,21 +140,21 @@ describe('the count of loops saved against each clip', () => {
    it was last worked on. Kept separate from `withLoopCounts` rather than folded
    into it — two facts, arriving by the same route but answering to different
    questions, and a function named for counting should not quietly do both. */
-describe('when each clip was last practised', () => {
-  const PRACTISED = '2026-09-06T18:04:11.000Z'
+describe('when each clip was last opened', () => {
+  const OPENED = '2026-09-06T18:04:11.000Z'
 
   const twoClips = loaded(LOADING, [
     getClip({ id: 'shuffle-drill' }),
     getClip({ id: 'pivot-turn' }),
   ])
 
-  it('gives each clip the moment it was last practised', () => {
-    const dated = withPractised(twoClips, (clipId) =>
-      clipId === 'shuffle-drill' ? PRACTISED : undefined,
+  it('gives each clip the moment it was last opened', () => {
+    const dated = withOpened(twoClips, (clipId) =>
+      clipId === 'shuffle-drill' ? OPENED : undefined,
     )
 
-    expect(dated.clips.map(({ id, practised }) => [id, practised])).toEqual([
-      ['shuffle-drill', PRACTISED],
+    expect(dated.clips.map(({ id, opened }) => [id, opened])).toEqual([
+      ['shuffle-drill', OPENED],
       ['pivot-turn', undefined],
     ])
   })
@@ -163,22 +163,22 @@ describe('when each clip was last practised', () => {
     const clip = getClip({ id: 'shuffle-drill', loops: 2 })
 
     expect(
-      withPractised(loaded(LOADING, [clip]), () => PRACTISED).clips[0],
-    ).toEqual({ ...clip, practised: PRACTISED })
+      withOpened(loaded(LOADING, [clip]), () => OPENED).clips[0],
+    ).toEqual({ ...clip, opened: OPENED })
   })
 
   /* Which is most of a real library, and the chip has to draw them: never
-     practised is a clip to sort last, not a clip to leave out. */
-  it('leaves a clip that has never been practised without a date', () => {
+     opened is a clip to sort last, not a clip to leave out. */
+  it('leaves a clip that has never been opened without a date', () => {
     expect(
-      withPractised(twoClips, () => undefined).clips.map(
-        ({ practised }) => practised,
+      withOpened(twoClips, () => undefined).clips.map(
+        ({ opened }) => opened,
       ),
     ).toEqual([undefined, undefined])
   })
 
   it('keeps the rest of the library as it found it', () => {
-    const dated = withPractised(twoClips, () => PRACTISED)
+    const dated = withOpened(twoClips, () => OPENED)
 
     expect(dated.state).toBe('ready')
     expect(dated.uploading).toEqual(twoClips.uploading)

--- a/app/src/clips/library.ts
+++ b/app/src/clips/library.ts
@@ -136,18 +136,18 @@ export const withLoopCounts = (
    the same file and arrive by the same route, but they answer different
    questions, and a function named for counting should not quietly do both —
    composing the two at the one call site says what is happening more plainly
-   than a `countFor`/`practisedFor` pair would.
+   than a `countFor`/`openedFor` pair would.
 
    Undefined is a real answer here rather than a gap: most of a library has
-   never been practised, and the chip has to draw those clips rather than leave
+   never been opened, and the chip has to draw those clips rather than leave
    them out. */
-export const withPractised = (
+export const withOpened = (
   library: Library,
-  practisedFor: (clipId: string) => string | undefined,
+  openedFor: (clipId: string) => string | undefined,
 ): Library => ({
   ...library,
   clips: library.clips.map((clip) => ({
     ...clip,
-    practised: practisedFor(clip.id),
+    opened: openedFor(clip.id),
   })),
 })

--- a/app/src/clips/openedStore.test.ts
+++ b/app/src/clips/openedStore.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  inMemoryStorage,
+  storageThatRefuses,
+} from '../drive/keyValueStorage.factory'
+import { localOpenedStore, OPENED_KEY } from './openedStore'
+
+const A_CLIP = 'shuffle-drill'
+const ANOTHER_CLIP = 'pivot-turn'
+
+const AT = '2026-09-06T18:04:11.000Z'
+const LATER = '2026-09-06T21:30:00.000Z'
+
+const written = (stamps: Record<string, unknown>) => JSON.stringify(stamps)
+
+/* When each clip was last opened *on this device* (#16). It lives here rather
+   than in `loops.json` because opening a clip is the commonest thing a session
+   does, and a Drive write per open would put the file holding the loops in the
+   path of an action worth nothing — four calls, and a refusal the dancer would
+   have to be told about, for an ordering. */
+describe('the clips this device has opened', () => {
+  it('knows nothing before anything has been opened', () => {
+    expect(localOpenedStore(inMemoryStorage()).read()).toEqual({})
+  })
+
+  it('remembers a clip that was opened', () => {
+    const storage = inMemoryStorage()
+    const store = localOpenedStore(storage)
+
+    store.stamp(A_CLIP, AT)
+
+    expect(store.read()).toEqual({ [A_CLIP]: AT })
+  })
+
+  /* The point of persisting rather than holding it in memory: the ordering has
+     to survive the reload that a phone gives you for free when it reclaims the
+     tab. */
+  it('survives a reload, because it is written to storage', () => {
+    const storage = inMemoryStorage()
+
+    localOpenedStore(storage).stamp(A_CLIP, AT)
+
+    expect(localOpenedStore(storage).read()).toEqual({ [A_CLIP]: AT })
+  })
+
+  it('moves the stamp on when the same clip is opened again', () => {
+    const store = localOpenedStore(inMemoryStorage())
+
+    store.stamp(A_CLIP, AT)
+    store.stamp(A_CLIP, LATER)
+
+    expect(store.read()).toEqual({ [A_CLIP]: LATER })
+  })
+
+  it('keeps a stamp per clip', () => {
+    const store = localOpenedStore(inMemoryStorage())
+
+    store.stamp(A_CLIP, AT)
+    store.stamp(ANOTHER_CLIP, LATER)
+
+    expect(store.read()).toEqual({ [A_CLIP]: AT, [ANOTHER_CLIP]: LATER })
+  })
+
+  /* Every rule below is the same one `loopsFile` makes about `touched`, for the
+     same reason: an ordering is not worth failing over. Nothing here can cost
+     the dancer a loop, so everything degrades to "nothing opened yet" rather
+     than throwing on a boot path. */
+  it('reads a body that is not JSON as nothing opened', () => {
+    expect(
+      localOpenedStore(inMemoryStorage({ [OPENED_KEY]: 'not json' })).read(),
+    ).toEqual({})
+  })
+
+  it('reads a body that is not a map as nothing opened', () => {
+    expect(
+      localOpenedStore(inMemoryStorage({ [OPENED_KEY]: '["nope"]' })).read(),
+    ).toEqual({})
+  })
+
+  it('drops a stamp that is not a time and keeps its siblings', () => {
+    expect(
+      localOpenedStore(
+        inMemoryStorage({
+          [OPENED_KEY]: written({ broken: 'last Tuesday-ish', kept: AT }),
+        }),
+      ).read(),
+    ).toEqual({ kept: AT })
+  })
+
+  /* Same normalisation `loopsFile` does, and it has to be the same because the
+     two maps are compared against each other to answer "when was this opened":
+     these are ordered as plain strings, which is chronological only in UTC. */
+  it('normalises a stamp that arrived in some other time zone', () => {
+    expect(
+      localOpenedStore(
+        inMemoryStorage({
+          [OPENED_KEY]: written({ [A_CLIP]: '2026-09-06T19:04:11+02:00' }),
+        }),
+      ).read(),
+    ).toEqual({ [A_CLIP]: '2026-09-06T17:04:11.000Z' })
+  })
+
+  /* A private window, or a quota already full. This runs on boot and on every
+     open, so throwing would be a white screen or a dead tile — and the cost of
+     swallowing it is an ordering that forgets, which is the right way round. */
+  it('survives storage that refuses to be read', () => {
+    expect(localOpenedStore(storageThatRefuses()).read()).toEqual({})
+  })
+
+  it('survives storage that refuses to be written', () => {
+    const store = localOpenedStore(storageThatRefuses())
+
+    expect(() => {
+      store.stamp(A_CLIP, AT)
+    }).not.toThrow()
+  })
+})

--- a/app/src/clips/openedStore.ts
+++ b/app/src/clips/openedStore.ts
@@ -1,0 +1,96 @@
+import type { KeyValueStorage } from '../drive/tokenStore'
+
+/* When each clip was last opened, as **this device** saw it (#16) — which is
+   what the **Last opened** chip orders by.
+
+   `localStorage`, and that is the whole design rather than a shortcut. Opening
+   a clip is the commonest thing a practice session does; a Drive write per open
+   would be four calls each time, aimed at the one file that holds the loops, and
+   every one of them another chance at the `moved` / `unreadable` refusal — a
+   refusal the dancer has to be told about. Paying that for an ordering would be
+   the wrong way round, so the stamp lands here instantly and rides the next
+   `loops.json` write to Drive (`withOpens`) rather than making one.
+
+   The same seam `tokenStore` and `loopsCache` name, for the same reason: jsdom
+   has no real `localStorage`. */
+export const OPENED_KEY = 'looper.opened'
+
+export type OpenedStore = {
+  readonly read: () => Readonly<Record<string, string>>
+  readonly stamp: (clipId: string, at: string) => void
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/* Both rules are `loopsFile`'s, deliberately identical: a string is not yet a
+   time, and a time is not yet a *comparable* one. The two maps are compared
+   against each other to answer "when was this last opened", and that comparison
+   is a plain string order — chronological only in UTC. */
+const isTime = (value: unknown): value is string =>
+  typeof value === 'string' && Number.isFinite(Date.parse(value))
+
+const asUtc = (at: string) => new Date(at).toISOString()
+
+/* Everything degrades to "nothing opened yet". Nothing here is the asset — the
+   loops are — so there is no reading of this file worth failing over, and this
+   runs on boot where a throw would be a white screen. */
+const stampsFrom = (raw: string | null): Readonly<Record<string, string>> => {
+  if (raw === null) return {}
+
+  try {
+    const held: unknown = JSON.parse(raw)
+
+    if (!isRecord(held)) return {}
+
+    return Object.fromEntries(
+      Object.entries(held).flatMap<[string, string]>(([clipId, at]) =>
+        isTime(at) ? [[clipId, asUtc(at)]] : [],
+      ),
+    )
+  } catch {
+    return {}
+  }
+}
+
+export const localOpenedStore = (storage: KeyValueStorage): OpenedStore => {
+  const read = () => {
+    /* A private window and a locked-down storage both throw rather than
+       answering, and this is on the boot path. */
+    try {
+      return stampsFrom(storage.getItem(OPENED_KEY))
+    } catch {
+      return {}
+    }
+  }
+
+  return {
+    read,
+
+    stamp: (clipId, at) => {
+      /* Swallowed, because the alternative is a clip that will not open. A
+         quota already full costs the ordering, never a loop — nothing is stored
+         only here that the dancer would miss. */
+      try {
+        storage.setItem(
+          OPENED_KEY,
+          JSON.stringify({ ...read(), [clipId]: asUtc(at) }),
+        )
+      } catch {
+        /* the ordering forgets this one open */
+      }
+    },
+  }
+}
+
+/* Injected from `App`, exactly as `browserLoopsCache` and `browserDriveApi`
+   are, so importing this module never touches the global. */
+export const browserOpenedStore = localOpenedStore({
+  getItem: (key) => localStorage.getItem(key),
+  setItem: (key, value) => {
+    localStorage.setItem(key, value)
+  },
+  removeItem: (key) => {
+    localStorage.removeItem(key)
+  },
+})

--- a/app/src/clips/ordering.ts
+++ b/app/src/clips/ordering.ts
@@ -20,19 +20,19 @@ export const orderings = [
      day a clip was uploaded and never changes again, so a clip added in July and
      drilled last night sorts below six that were added and never opened.
 
-     `''` for a clip never practised, which puts the whole never-practised tail
+     `''` for a clip never opened, which puts the whole never-opened tail
      below every clip that has been — most of a real library. A fallback date
      would be worse than wrong: it would let one of them tie with a clip that
-     genuinely was practised then.
+     genuinely was opened then.
 
      Last of the four rather than beside **Recent**, so `orderings[0]` stays
      Recent — that is both the default and where the grid jumps back to after an
      add (`ClipsScreen`). */
   {
-    id: 'practised',
-    label: 'Last practised',
+    id: 'opened',
+    label: 'Last opened',
     compare: (a: Clip, b: Clip) =>
-      (b.practised ?? '').localeCompare(a.practised ?? ''),
+      (b.opened ?? '').localeCompare(a.opened ?? ''),
   },
 ] as const
 

--- a/app/src/loops/applyToLoops.test.ts
+++ b/app/src/loops/applyToLoops.test.ts
@@ -12,12 +12,6 @@ import { NO_LOOPS, serialiseLoops } from './loopsFile'
 const A_CLIP = 'shuffle-drill'
 const THE_OTHER_CLIP = 'pivot-turn'
 
-/* When the change was made. Nothing here is about the stamp — that is
-   `loopsChange.test.ts` — but it rides every write, so it shows up in the
-   bodies these tests read back. */
-const AT = '2026-09-06T18:04:11.000Z'
-const PRACTISED = { [A_CLIP]: AT }
-
 const holding = (
   clips: Record<string, readonly SavedLoop[]>,
   versions: readonly string[] = ['3', '3'],
@@ -45,7 +39,7 @@ describe('writing a change back to Drive', () => {
     const api = holding({})
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, getLoop(), AT),
+      withLoop(loops, A_CLIP, getLoop()),
     )
 
     expect(api.writeJson).toHaveBeenCalledWith(
@@ -62,13 +56,9 @@ describe('writing a change back to Drive', () => {
 
     await expect(
       applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-        withLoop(loops, A_CLIP, loop, AT),
+        withLoop(loops, A_CLIP, loop),
       ),
-    ).resolves.toEqual({
-      ...NO_LOOPS,
-      clips: { [A_CLIP]: [loop] },
-      touched: PRACTISED,
-    })
+    ).resolves.toEqual({ ...NO_LOOPS, clips: { [A_CLIP]: [loop] } })
   })
 
   /* UC-01 Q-05, and the whole reason this is a read-modify-write rather than a
@@ -81,13 +71,13 @@ describe('writing a change back to Drive', () => {
     const api = holding({ [THE_OTHER_CLIP]: [theirs] })
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, mine, AT),
+      withLoop(loops, A_CLIP, mine),
     )
 
     expect(bodyWritten(api)).toEqual({
       schema: 1,
       clips: { [THE_OTHER_CLIP]: [theirs], [A_CLIP]: [mine] },
-      touched: PRACTISED,
+      touched: {},
     })
   })
 
@@ -97,13 +87,13 @@ describe('writing a change back to Drive', () => {
     const api = holding({ [A_CLIP]: [going, kept] })
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withoutLoop(loops, A_CLIP, 'going', AT),
+      withoutLoop(loops, A_CLIP, 'going'),
     )
 
     expect(bodyWritten(api)).toEqual({
       schema: 1,
       clips: { [A_CLIP]: [kept] },
-      touched: PRACTISED,
+      touched: {},
     })
   })
 })
@@ -114,7 +104,7 @@ describe('the first save of all', () => {
     const api = aDriveApi()
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, loop, AT),
+      withLoop(loops, A_CLIP, loop),
     )
 
     expect(api.createJson).toHaveBeenCalledWith(A_TOKEN, {
@@ -124,7 +114,7 @@ describe('the first save of all', () => {
     expect(bodyWritten(api)).toEqual({
       schema: 1,
       clips: { [A_CLIP]: [loop] },
-      touched: PRACTISED,
+      touched: {},
     })
   })
 })
@@ -140,7 +130,7 @@ describe('a file nobody can read', () => {
     })
 
     const refused = await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, getLoop(), AT),
+      withLoop(loops, A_CLIP, getLoop()),
     ).catch((error: unknown) => error)
 
     expect(refused).toBeInstanceOf(LoopsRefused)
@@ -156,7 +146,7 @@ describe('a write that lands inside our own round trip', () => {
     const api = holding({}, ['3', '4', '4', '4'])
 
     await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, getLoop(), AT),
+      withLoop(loops, A_CLIP, getLoop()),
     )
 
     expect(api.readJson).toHaveBeenCalledTimes(2)
@@ -169,7 +159,7 @@ describe('a write that lands inside our own round trip', () => {
     const api = holding({}, ['3', '4', '4', '5'])
 
     const refused = await applyToLoops(api, A_TOKEN, A_FOLDER, (loops) =>
-      withLoop(loops, A_CLIP, getLoop(), AT),
+      withLoop(loops, A_CLIP, getLoop()),
     ).catch((error: unknown) => error)
 
     expect(refused).toBeInstanceOf(LoopsRefused)

--- a/app/src/loops/loopsChange.test.ts
+++ b/app/src/loops/loopsChange.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { getLoop } from './loop.factory'
 import {
   countOf,
+  laterOf,
   loopsFor,
-  practisedAt,
+  openedAt,
   withLoop,
+  withOpens,
   withoutLoop,
 } from './loopsChange'
 import { NO_LOOPS } from './loopsFile'
@@ -16,6 +18,8 @@ const ANOTHER_CLIP = 'pivot-turn'
 /* When the change being made happened. Every one of these functions takes it
    rather than reading a clock, so the merge below is testable as arithmetic. */
 const AT = '2026-09-06T18:04:11.000Z'
+const EARLIER = '2026-09-06T09:00:00.000Z'
+const LATER = '2026-09-06T21:30:00.000Z'
 
 const holding = (
   clips: Record<string, ReturnType<typeof getLoop>[]>,
@@ -128,14 +132,82 @@ describe('what a clip has', () => {
     ).toBe(2)
   })
 
-  it('says when it was last practised', () => {
-    expect(practisedAt(holding({}, { [A_CLIP]: AT }), A_CLIP)).toBe(AT)
+  it('says when it was last opened', () => {
+    expect(openedAt(holding({}, { [A_CLIP]: AT }), A_CLIP)).toBe(AT)
   })
 
-  /* Undefined rather than a fallback date. "Never practised" is not "practised
+  /* Undefined rather than a fallback date. "Never opened" is not "opened
      at the beginning of time" — the chip has to sort it below every clip that
      has been, and a real date would let it tie with one. */
-  it('says nothing for a clip that has never been practised', () => {
-    expect(practisedAt(NO_LOOPS, 'no-such-clip')).toBeUndefined()
+  it('says nothing for a clip that has never been opened', () => {
+    expect(openedAt(NO_LOOPS, 'no-such-clip')).toBeUndefined()
+  })
+})
+
+/* #16 — the opens this device recorded, carried into `loops.json` by the write a
+   loop save or removal was already making. There is no write of their own: the
+   whole point of keeping them on the device is that opening a clip costs Drive
+   nothing. */
+describe('carrying this device\u2019s opens into the file', () => {
+  it('adds a stamp for a clip the file had never heard of', () => {
+    expect(withOpens(NO_LOOPS, { [A_CLIP]: AT }).touched).toEqual({
+      [A_CLIP]: AT,
+    })
+  })
+
+  it('carries every clip it is given, and leaves the loops alone', () => {
+    const held = holding({ [A_CLIP]: [getLoop()] })
+
+    const carried = withOpens(held, { [A_CLIP]: AT, [ANOTHER_CLIP]: LATER })
+
+    expect(carried.clips).toEqual(held.clips)
+    expect(carried.touched).toEqual({ [A_CLIP]: AT, [ANOTHER_CLIP]: LATER })
+  })
+
+  it('moves a stamp on when this device opened the clip more recently', () => {
+    expect(
+      withOpens(holding({}, { [A_CLIP]: EARLIER }), { [A_CLIP]: LATER }).touched,
+    ).toEqual({ [A_CLIP]: LATER })
+  })
+
+  /* The merge rule, and why this is `max` rather than an assignment.
+     `applyToLoops` replays the change onto whatever Drive holds *now*, so a
+     laptop that has been shut for a week must not drag a clip's recency
+     backwards over what the phone wrote while it was away. */
+  it('leaves a later stamp standing when this device is behind', () => {
+    expect(
+      withOpens(holding({}, { [A_CLIP]: LATER }), { [A_CLIP]: EARLIER }).touched,
+    ).toEqual({ [A_CLIP]: LATER })
+  })
+
+  it('leaves a clip this device has not opened exactly as it was', () => {
+    expect(
+      withOpens(holding({}, { [ANOTHER_CLIP]: EARLIER }), { [A_CLIP]: AT })
+        .touched,
+    ).toEqual({ [ANOTHER_CLIP]: EARLIER, [A_CLIP]: AT })
+  })
+
+  it('is a no-op when this device has opened nothing', () => {
+    const held = holding({ [A_CLIP]: [getLoop()] }, { [A_CLIP]: AT })
+
+    expect(withOpens(held, {})).toEqual(held)
+  })
+})
+
+/* The same rule the grid reads with: this device's own record and Drive's may
+   each be ahead of the other, and the honest answer is the later one. */
+describe('the later of two stamps', () => {
+  it('takes whichever is later', () => {
+    expect(laterOf(EARLIER, LATER)).toBe(LATER)
+    expect(laterOf(LATER, EARLIER)).toBe(LATER)
+  })
+
+  it('takes the one that exists when only one does', () => {
+    expect(laterOf(undefined, AT)).toBe(AT)
+    expect(laterOf(AT, undefined)).toBe(AT)
+  })
+
+  it('is undefined when neither does', () => {
+    expect(laterOf(undefined, undefined)).toBeUndefined()
   })
 })

--- a/app/src/loops/loopsChange.test.ts
+++ b/app/src/loops/loopsChange.test.ts
@@ -16,8 +16,6 @@ const ANOTHER_CLIP = 'pivot-turn'
 /* When the change being made happened. Every one of these functions takes it
    rather than reading a clock, so the merge below is testable as arithmetic. */
 const AT = '2026-09-06T18:04:11.000Z'
-const EARLIER = '2026-09-06T09:00:00.000Z'
-const LATER = '2026-09-06T21:30:00.000Z'
 
 const holding = (
   clips: Record<string, ReturnType<typeof getLoop>[]>,
@@ -32,8 +30,8 @@ describe('adding a loop', () => {
   it('starts the list for a clip that had none', () => {
     const loop = getLoop()
 
-    expect(withLoop(NO_LOOPS, A_CLIP, loop, AT)).toEqual(
-      holding({ [A_CLIP]: [loop] }, { [A_CLIP]: AT }),
+    expect(withLoop(NO_LOOPS, A_CLIP, loop)).toEqual(
+      holding({ [A_CLIP]: [loop] }),
     )
   })
 
@@ -42,7 +40,7 @@ describe('adding a loop', () => {
     const second = getLoop({ id: 'second' })
 
     expect(
-      withLoop(holding({ [A_CLIP]: [first] }), A_CLIP, second, AT).clips[A_CLIP],
+      withLoop(holding({ [A_CLIP]: [first] }), A_CLIP, second).clips[A_CLIP],
     ).toEqual([first, second])
   })
 
@@ -53,7 +51,7 @@ describe('adding a loop', () => {
     const theirs = getLoop({ id: 'theirs' })
 
     expect(
-      withLoop(holding({ [ANOTHER_CLIP]: [theirs] }), A_CLIP, mine, AT).clips,
+      withLoop(holding({ [ANOTHER_CLIP]: [theirs] }), A_CLIP, mine).clips,
     ).toEqual({ [ANOTHER_CLIP]: [theirs], [A_CLIP]: [mine] })
   })
 })
@@ -64,8 +62,8 @@ describe('removing a loop', () => {
     const going = getLoop({ id: 'going' })
 
     expect(
-      withoutLoop(holding({ [A_CLIP]: [kept, going] }), A_CLIP, 'going', AT),
-    ).toEqual(holding({ [A_CLIP]: [kept] }, { [A_CLIP]: AT }))
+      withoutLoop(holding({ [A_CLIP]: [kept, going] }), A_CLIP, 'going'),
+    ).toEqual(holding({ [A_CLIP]: [kept] }))
   })
 
   /* Matches what the reader does with a clip whose every entry was malformed:
@@ -76,10 +74,8 @@ describe('removing a loop', () => {
       withoutLoop(
         holding({ [A_CLIP]: [getLoop({ id: 'only' })] }),
         A_CLIP,
-        'only',
-        AT,
-      ),
-    ).toEqual(holding({}, { [A_CLIP]: AT }))
+        'only'),
+    ).toEqual(NO_LOOPS)
   })
 
   it('leaves every other clip exactly as it was', () => {
@@ -90,9 +86,8 @@ describe('removing a loop', () => {
         holding({ [A_CLIP]: [getLoop({ id: 'mine' })], [ANOTHER_CLIP]: [theirs] }),
         A_CLIP,
         'mine',
-        AT,
       ),
-    ).toEqual(holding({ [ANOTHER_CLIP]: [theirs] }, { [A_CLIP]: AT }))
+    ).toEqual(holding({ [ANOTHER_CLIP]: [theirs] }))
   })
 
   /* Both of these happen for real: the other device removed it first, and the
@@ -100,75 +95,11 @@ describe('removing a loop', () => {
   it('is a no-op for an id that is not there', () => {
     const held = holding({ [A_CLIP]: [getLoop()] })
 
-    expect(withoutLoop(held, A_CLIP, 'never-saved', AT).clips).toEqual(held.clips)
+    expect(withoutLoop(held, A_CLIP, 'never-saved')).toEqual(held)
   })
 
   it('is a no-op for a clip that is not there', () => {
-    expect(withoutLoop(NO_LOOPS, 'no-such-clip', 'loop-1', AT).clips).toEqual({})
-  })
-})
-
-/* #12 — the last time a loop was saved on a clip or removed from it, which is
-   what the **Last practised** chip orders by. The stamp rides the two writes
-   that already happen rather than adding a third, which is the whole reason
-   practising is defined as loop edits and not as opening the player. */
-describe('stamping a clip as practised', () => {
-  it('stamps the clip a loop was saved on', () => {
-    expect(withLoop(NO_LOOPS, A_CLIP, getLoop(), AT).touched).toEqual({
-      [A_CLIP]: AT,
-    })
-  })
-
-  /* A removal is working on the clip too, so it stamps — including the removal
-     that empties it. That is why the stamp is a sibling of `clips` rather than
-     a field on a loop: it has to outlive the loops it was made by. */
-  it('stamps the clip a loop was removed from, even as its last loop goes', () => {
-    const emptied = withoutLoop(
-      holding({ [A_CLIP]: [getLoop({ id: 'only' })] }),
-      A_CLIP,
-      'only',
-      AT,
-    )
-
-    expect(emptied.clips).toEqual({})
-    expect(emptied.touched).toEqual({ [A_CLIP]: AT })
-  })
-
-  it('moves the stamp on when the same clip is practised again', () => {
-    expect(
-      withLoop(holding({}, { [A_CLIP]: EARLIER }), A_CLIP, getLoop(), LATER)
-        .touched,
-    ).toEqual({ [A_CLIP]: LATER })
-  })
-
-  /* The merge rule, and the reason this is `max` rather than an assignment.
-     `applyToLoops` replays the change onto whatever Drive holds *now*, so a
-     stamp captured before that round trip can arrive after a newer one the
-     phone already wrote. Taking the later of the two is what stops the laptop
-     dragging a clip's recency backwards. */
-  it('leaves a later stamp standing when an earlier change is replayed onto it', () => {
-    expect(
-      withLoop(holding({}, { [A_CLIP]: LATER }), A_CLIP, getLoop(), EARLIER)
-        .touched,
-    ).toEqual({ [A_CLIP]: LATER })
-  })
-
-  /* The rule `withClip` states and nothing else pins: a removal replayed onto a
-     file the other device has already removed from changes no loops, but the
-     dancer still pressed the button, so it still stamps. The two no-op tests
-     above assert only `.clips`, which is exactly what leaves this unguarded. */
-  it('stamps a removal that removes nothing', () => {
-    expect(
-      withoutLoop(holding({ [A_CLIP]: [getLoop()] }), A_CLIP, 'never-saved', AT)
-        .touched,
-    ).toEqual({ [A_CLIP]: AT })
-  })
-
-  it('leaves every other clip’s stamp exactly as it was', () => {
-    expect(
-      withLoop(holding({}, { [ANOTHER_CLIP]: EARLIER }), A_CLIP, getLoop(), AT)
-        .touched,
-    ).toEqual({ [ANOTHER_CLIP]: EARLIER, [A_CLIP]: AT })
+    expect(withoutLoop(NO_LOOPS, 'no-such-clip', 'loop-1')).toEqual(NO_LOOPS)
   })
 })
 

--- a/app/src/loops/loopsChange.ts
+++ b/app/src/loops/loopsChange.ts
@@ -13,6 +13,24 @@ import type { LoopsFile } from './loopsFile'
    Everything here is a plain function of a `LoopsFile`, so the same code path
    serves the optimistic local answer and the write that goes to Drive. */
 
+/* The later of the two, and a plain string comparison because the stamps are
+   ISO-8601 UTC — the one format whose lexical order is its chronological order.
+   Both sides may be missing: a clip this device has never opened, in a file that
+   has never heard of it either.
+
+   `max` rather than an assignment wherever it is used, and that is the merge
+   rule rather than caution. Two clocks that disagree cost minutes here, which is
+   nothing against a chip measured in days. */
+export const laterOf = (
+  held: string | undefined,
+  other: string | undefined,
+): string | undefined => {
+  if (held === undefined) return other
+  if (other === undefined) return held
+
+  return held > other ? held : other
+}
+
 /* A clip with no loops is not in the file at all, which is the same rule
    `readLoopsFile` applies to a clip whose every entry was malformed. Keeping an
    empty list would give the two readings of "this clip has nothing" a way to
@@ -47,14 +65,38 @@ export const loopsFor = (
 export const countOf = (loops: LoopsFile, clipId: string) =>
   loopsFor(loops, clipId).length
 
-/* What the **Last practised** chip orders by (#12). Undefined rather than a
-   fallback date, because "never practised" is not "practised at the beginning
-   of time": the chip sorts the never-practised below every clip that has been,
-   and any real date would let one of them tie with a clip that has. */
-export const practisedAt = (
+/* What Drive knows about when this clip was last opened (#16) — which may be
+   another device's answer, and may be behind this one's. The grid takes the
+   later of the two (`laterOf`).
+
+   Undefined rather than a fallback date, because "never opened" is not "opened
+   at the beginning of time": the chip sorts the never-opened below every clip
+   that has been, and any real date would let one of them tie with a clip that
+   genuinely was opened then. */
+export const openedAt = (
   loops: LoopsFile,
   clipId: string,
 ): string | undefined => loops.touched[clipId]
+
+/* The opens this device recorded, folded into the file on their way to Drive
+   (#16). They ride the write a loop save or removal was already making — there
+   is no write of their own, which is the whole reason opening a clip is free.
+
+   Per clip the later stamp wins, so replaying a laptop's week-old opens onto
+   what the phone has since written cannot drag anything backwards. */
+export const withOpens = (
+  loops: LoopsFile,
+  opens: Readonly<Record<string, string>>,
+): LoopsFile => ({
+  ...loops,
+  touched: Object.entries(opens).reduce<Record<string, string>>(
+    (held, [clipId, at]) => ({
+      ...held,
+      [clipId]: laterOf(held[clipId], at) ?? at,
+    }),
+    { ...loops.touched },
+  ),
+})
 
 /* At the end, because that is the order the panel lists them in and the order
    the dancer saved them in. */

--- a/app/src/loops/loopsChange.ts
+++ b/app/src/loops/loopsChange.ts
@@ -13,36 +13,19 @@ import type { LoopsFile } from './loopsFile'
    Everything here is a plain function of a `LoopsFile`, so the same code path
    serves the optimistic local answer and the write that goes to Drive. */
 
-/* The later of the two, and a plain string comparison because the stamps are
-   ISO-8601 UTC — the one format whose lexical order is its chronological order.
-
-   `max` rather than an assignment, and that is the merge rule rather than
-   caution. `applyToLoops` replays this change onto whatever Drive holds *now*,
-   so a stamp captured before that round trip can land on top of a newer one the
-   phone already wrote. Assigning would let a laptop that has been offline drag
-   a clip's recency backwards. Two clocks that disagree cost minutes here, which
-   is nothing against a chip measured in days. */
-const laterOf = (held: string | undefined, at: string) =>
-  held !== undefined && held > at ? held : at
-
 /* A clip with no loops is not in the file at all, which is the same rule
    `readLoopsFile` applies to a clip whose every entry was malformed. Keeping an
    empty list would give the two readings of "this clip has nothing" a way to
    disagree.
 
-   The stamp is not filtered the same way, on purpose: a clip whose last loop
-   has just been removed is a clip that was just practised, so its `touched`
-   entry outlives the loops that earned it (#12).
-
-   Every change through here stamps, with no exception for one that removes
-   nothing. A removal replayed onto a file the other device already removed from
-   changes no loops, but the dancer still pressed the button — the emptiness is
-   the merge's doing, not theirs. */
+   It leaves `touched` alone. Saving a loop is not what the fourth chip measures
+   any more (#16) — opening the clip is, and that is recorded on the device long
+   before this runs. A loop write carries those stamps (`withOpens`), but it does
+   not make one of its own. */
 const withClip = (
   loops: LoopsFile,
   clipId: string,
   saved: readonly SavedLoop[],
-  at: string,
 ): LoopsFile => ({
   ...loops,
   clips: Object.fromEntries(
@@ -50,7 +33,6 @@ const withClip = (
       ([, held]) => held.length > 0,
     ),
   ),
-  touched: { ...loops.touched, [clipId]: laterOf(loops.touched[clipId], at) },
 })
 
 export const loopsFor = (
@@ -75,31 +57,23 @@ export const practisedAt = (
 ): string | undefined => loops.touched[clipId]
 
 /* At the end, because that is the order the panel lists them in and the order
-   the dancer saved them in.
-
-   `at` is passed in rather than read from a clock here, which keeps this module
-   pure and — more usefully — makes the merge above something a test can state
-   as arithmetic rather than schedule. */
+   the dancer saved them in. */
 export const withLoop = (
   loops: LoopsFile,
   clipId: string,
   loop: SavedLoop,
-  at: string,
-): LoopsFile => withClip(loops, clipId, [...loopsFor(loops, clipId), loop], at)
+): LoopsFile => withClip(loops, clipId, [...loopsFor(loops, clipId), loop])
 
 /* A no-op for an id that is not there, and that is a real case rather than
    defensiveness: the other device may have removed it first, and the merge
-   replays this removal onto a file that has already lost it. A no-op for the
-   loops — it still stamps, for the reason `withClip` gives. */
+   replays this removal onto a file that has already lost it. */
 export const withoutLoop = (
   loops: LoopsFile,
   clipId: string,
   id: string,
-  at: string,
 ): LoopsFile =>
   withClip(
     loops,
     clipId,
     loopsFor(loops, clipId).filter((loop) => loop.id !== id),
-    at,
   )

--- a/app/src/loops/loopsFile.test.ts
+++ b/app/src/loops/loopsFile.test.ts
@@ -143,14 +143,14 @@ describe('a malformed loop among good ones', () => {
   })
 })
 
-/* When each clip was last worked on (#12), which is what the **Last practised**
+/* When each clip was last opened (#12), which is what the **Last opened**
    chip orders by.
 
    Recency is not the asset — the loops are — and every rule below follows from
    that one asymmetry. A stamp that cannot be read is dropped; a *loop* that
    cannot be read makes the whole file untouchable. Losing a stamp costs an
    ordering until the next save. Losing a loop costs the dancer their work. */
-describe('when a clip was last practised', () => {
+describe('when a clip was last opened', () => {
   it('reads back the stamps beside the loops', () => {
     const loop = getLoop()
 
@@ -169,9 +169,9 @@ describe('when a clip was last practised', () => {
   })
 
   /* Every `loops.json` in Drive predates this, and the dancer's loops are in
-     them. Reading one as anything other than "practised nothing yet" would be
+     them. Reading one as anything other than "opened nothing yet" would be
      the feature arriving by destroying what it was built to order. */
-  it('reads a file written before stamps existed as nothing practised yet', () => {
+  it('reads a file written before stamps existed as nothing opened yet', () => {
     const loop = getLoop()
 
     expect(readLoopsFile(written({ 'shuffle-drill': [loop] }))).toEqual({

--- a/app/src/loops/loopsFile.ts
+++ b/app/src/loops/loopsFile.ts
@@ -25,8 +25,8 @@ export const SCHEMA = 1
 export type LoopsFile = {
   readonly schema: typeof SCHEMA
   readonly clips: Readonly<Record<string, readonly SavedLoop[]>>
-  /* When each clip was last worked on — the last time a loop was saved on it or
-     removed from it (#12), which is what the **Last practised** chip orders by.
+  /* When each clip was last opened — the last time a loop was saved on it or
+     removed from it (#12), which is what the **Last opened** chip orders by.
      ISO-8601, always UTC, because that is the one format whose string order is
      its time order and the merge below compares them as strings.
 
@@ -34,7 +34,7 @@ export type LoopsFile = {
      the clip, and the clip it belongs to may have no loops left. Keyed the same
      way, so both maps survive a re-upload for the same reason.
 
-     Always present, empty when nothing has been practised, exactly as `clips`
+     Always present, empty when nothing has been opened, exactly as `clips`
      is — the "not carried around forever" rule (`withClip`) is about entries,
      not about the map. That keeps `LoopsFile` a total shape and spares every
      reader a `?? {}`. */
@@ -108,7 +108,7 @@ const isTime = (value: unknown): value is string =>
   typeof value === 'string' && Number.isFinite(Date.parse(value))
 
 /* And a time is not yet a *comparable* one. `laterOf` and the **Last
-   practised** chip both compare these as plain strings, which only orders
+   opened** chip both compare these as plain strings, which only orders
    chronologically for ISO-8601 UTC — so `…T19:04:11+02:00` would sort after
    `…T18:00:00.000Z` while being the earlier instant. `isTime` above admits
    every form `Date.parse` understands, so the same door that accepts a stamp

--- a/app/src/loops/loopsHandle.factory.ts
+++ b/app/src/loops/loopsHandle.factory.ts
@@ -56,24 +56,15 @@ export const useFakeLoops = ({
     [held, refuses],
   )
 
-  /* A real clock, as `useLoops` uses — the fake is standing in for Drive, not
-     for time, and a frozen stamp would let a test pass that the real hook
-     fails. */
   const save = useCallback(
-    (clipId: string, loop: SavedLoop) => {
-      const at = new Date().toISOString()
-
-      return write((current) => withLoop(current, clipId, loop, at))
-    },
+    (clipId: string, loop: SavedLoop) =>
+      write((current) => withLoop(current, clipId, loop)),
     [write],
   )
 
   const remove = useCallback(
-    (clipId: string, id: string) => {
-      const at = new Date().toISOString()
-
-      return write((current) => withoutLoop(current, clipId, id, at))
-    },
+    (clipId: string, id: string) =>
+      write((current) => withoutLoop(current, clipId, id)),
     [write],
   )
 

--- a/app/src/loops/useLoops.test.tsx
+++ b/app/src/loops/useLoops.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { DriveApi } from '../drive/driveApi'
 import { DriveError } from '../drive/driveApi'
@@ -323,62 +323,5 @@ describe('removing a loop', () => {
       expect(result.current.notice).not.toBeNull()
     })
     expect(result.current.loops.clips).toEqual({ [A_CLIP]: [loop] })
-  })
-})
-
-/* #12 — this is the hook's only share of the feature: it is where the clock is
-   read. What the stamp *means* once it exists is `loopsChange.test.ts`.
-
-   The write that carries it is the write that was already happening, which is
-   the whole design: the failure criterion above ("a write that did not land
-   adds nothing") extends to recency for free, because there is no second call
-   that could leave Drive claiming a clip was practised while the loop that was
-   practised on it never arrived. */
-describe('stamping the clip as practised', () => {
-  const PRACTISED = '2026-09-06T18:04:11.000Z'
-
-  beforeEach(() => {
-    /* `shouldAdvanceTime`, so the promises inside a save still settle — the
-       clock is being pinned to a known reading, not stopped. */
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    vi.setSystemTime(new Date(PRACTISED))
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('sends the stamp to Drive in the same body as the loop', async () => {
-    const loop = getLoop()
-    const api = holding({})
-
-    const { result } = renderLoops(api)
-
-    await result.current.save(A_CLIP, loop)
-
-    expect(bodyWritten(api)).toEqual({
-      ...NO_LOOPS,
-      clips: { [A_CLIP]: [loop] },
-      touched: { [A_CLIP]: PRACTISED },
-    })
-  })
-
-  it('stamps a removal as readily as a save', async () => {
-    const api = holding({ [A_CLIP]: [getLoop({ id: 'going' })] })
-
-    const { result } = renderLoops(api)
-
-    await waitFor(() => {
-      expect(result.current.loops.clips[A_CLIP]).toHaveLength(1)
-    })
-
-    /* Re-pinned here rather than only in `beforeEach`: the clock advances with
-       real time so the wait above can finish, and what is being asserted is the
-       reading at the moment of the removal. */
-    vi.setSystemTime(new Date(PRACTISED))
-
-    await result.current.remove(A_CLIP, 'going')
-
-    expect(bodyWritten(api).touched).toEqual({ [A_CLIP]: PRACTISED })
   })
 })

--- a/app/src/loops/useLoops.ts
+++ b/app/src/loops/useLoops.ts
@@ -5,7 +5,7 @@ import { withdrewConsent } from '../drive/driveErrors'
 import { useDriveSession } from '../drive/driveSession'
 import { applyToLoops, type LoopsChange, LoopsRefused, readLoops } from './driveLoops'
 import type { SavedLoop } from './loop'
-import { withLoop, withoutLoop } from './loopsChange'
+import { withLoop, withOpens, withoutLoop } from './loopsChange'
 import type { LoopsCache } from './loopsCache'
 import { browserLoopsCache } from './loopsCache'
 import type { LoopsFile } from './loopsFile'
@@ -53,6 +53,13 @@ const noticeFor = (error: unknown, what: string) => {
 export const useLoops = (
   api: DriveApi,
   cache: LoopsCache = browserLoopsCache,
+  /* What this device has opened, read at the moment of a write rather than
+     captured (#16). These stamps ride the write a loop save or removal was
+     already making — there is deliberately no write of their own, because
+     `loops.json` holds the loops and an ordering is not worth putting it in
+     the path of every open. A getter rather than a value so the write always
+     carries what is true now, not what was true when this hook rendered. */
+  opens: () => Readonly<Record<string, string>> = () => ({}),
 ): LoopsHandle => {
   const { status, requireToken, reportConsentWithdrawn } = useDriveSession()
   /* Seeded from the local copy rather than from nothing, which is BR-13's
@@ -141,11 +148,17 @@ export const useLoops = (
            upload's tile-first flow — and the difference is the wait being
            covered: thirteen seconds there, about two hundred milliseconds
            here. */
+        /* Folded in *inside* the change, so it is replayed onto whatever Drive
+           holds now exactly as the loop edit is — and so a retry carries them
+           too. `withOpens` keeps the later stamp per clip, so a device that has
+           been shut for a week cannot drag anything backwards. */
+        const carrying = opens()
+
         const next = await applyToLoops(
           api,
           reached.token,
           reached.folderId,
-          change,
+          (held) => withOpens(change(held), carrying),
         )
 
         setLoops(next)
@@ -161,7 +174,7 @@ export const useLoops = (
         setWriting(false)
       }
     },
-    [api, cache, folderToken, reportIfWithdrawn],
+    [api, cache, folderToken, opens, reportIfWithdrawn],
   )
 
   const save = useCallback(

--- a/app/src/loops/useLoops.ts
+++ b/app/src/loops/useLoops.ts
@@ -28,17 +28,6 @@ export type LoopsHandle = {
   readonly remove: (clipId: string, id: string) => Promise<boolean>
 }
 
-/* The moment the dancer pressed the button, which is what `touched` records
-   (#12). Taken here, once, rather than inside the change handed to
-   `applyToLoops`: that change may be replayed on a retry, and the stamp is
-   about what the dancer did rather than which attempt happened to land. Keeping
-   the clock out of it also keeps `LoopsChange` a pure function of the file,
-   which is what makes the merge replayable in the first place.
-
-   UTC, because `touched` is compared as a string and only this format sorts
-   chronologically when it is. */
-const practisedNow = () => new Date().toISOString()
-
 /* Deliberately different sentences, because the dancer can act on the
    difference. "Could not be read" also carries the news that their existing
    loops are still there, in a file this app has refused to touch — reporting
@@ -176,11 +165,8 @@ export const useLoops = (
   )
 
   const save = useCallback(
-    (clipId: string, loop: SavedLoop) => {
-      const at = practisedNow()
-
-      return write((held) => withLoop(held, clipId, loop, at), `“${loop.name}”`)
-    },
+    (clipId: string, loop: SavedLoop) =>
+      write((held) => withLoop(held, clipId, loop), `“${loop.name}”`),
     [write],
   )
 
@@ -188,11 +174,8 @@ export const useLoops = (
      to is still on screen when the sentence appears — the dancer can see which
      one it is, and a name repeated back adds nothing. */
   const remove = useCallback(
-    (clipId: string, id: string) => {
-      const at = practisedNow()
-
-      return write((held) => withoutLoop(held, clipId, id, at), 'That removal')
-    },
+    (clipId: string, id: string) =>
+      write((held) => withoutLoop(held, clipId, id), 'That removal'),
     [write],
   )
 

--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -94,6 +94,7 @@ const Player = ({
 
   return (
     <PlayerScreen
+      onOpened={noOpenIsRecorded}
       clips={clips}
       driveApi={driveApi}
       clipCache={holdsNothing}
@@ -102,6 +103,9 @@ const Player = ({
     />
   )
 }
+
+/* #16 stamps the clip on open; nothing in this file is about that. */
+const noOpenIsRecorded = () => {}
 
 const renderPlayerFetching = (
   { loaded, total }: { readonly loaded: number; readonly total: number },

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -152,6 +152,7 @@ function Opening() {
 }
 
 export function PlayerScreen({
+  onOpened,
   clips,
   loops,
   driveApi = browserDriveApi,
@@ -160,6 +161,10 @@ export function PlayerScreen({
   stillLoading = false,
 }: {
   readonly clips: readonly Clip[]
+  /* Fired once the path has resolved to a clip the library holds (#16), which
+     is what **Last opened** orders by. Not on every render and not before the
+     bounce: a path naming no clip is not an open. */
+  readonly onOpened: (clipId: string) => void
   /* The loops, from above both screens. The player no longer keeps a list of
      its own: US-01-15 puts them in Drive, and the Clips screen counts the same
      ones, so a second copy read separately would be a second copy free to
@@ -201,6 +206,7 @@ export function PlayerScreen({
       driveApi={driveApi}
       clipCache={clipCache}
       onBytes={onBytes}
+      onOpened={onOpened}
     />
   )
 }
@@ -211,13 +217,24 @@ function OpenedClip({
   driveApi,
   clipCache,
   onBytes,
+  onOpened,
 }: {
   readonly clip: Clip
   readonly loops: LoopsHandle
   readonly driveApi: DriveApi
   readonly clipCache: ClipCache
   readonly onBytes?: ((clipId: string, bytes: Blob) => void) | undefined
+  readonly onOpened: (clipId: string) => void
 }) {
+  /* #16. Here rather than in the parent because this component is keyed on the
+     clip and mounted only once the path has resolved to one the library holds —
+     so it fires exactly once per open, and a path naming no clip never counts
+     as one. It does not wait for the bytes: the dancer opened the clip whether
+     or not Drive could produce it. */
+  useEffect(() => {
+    onOpened(clip.id)
+  }, [clip.id, onOpened])
+
   /* Named here rather than inline at the call below, because `useClipSource`
      depends on it: a new function each render would re-run its effect and
      re-fetch the clip every time anything on this screen changed. */

--- a/mockup/src/App.jsx
+++ b/mockup/src/App.jsx
@@ -7,11 +7,12 @@ import Player from './Player.jsx'
    separate clips rather than one clip chopped into pieces. The loops belonging
    to a clip live on the player screen; here they are only a count.
 
-   `practised` is when a loop was last saved on the clip or removed from it
-   (#12) — seeded rather than produced, because this player keeps its saved
-   loops to itself and never tells the list about them. The values run counter
-   to both `added` and `loops` on purpose: the clip added most recently was last
-   worked on a week ago, and two clips have never been worked on at all. That is
+   `opened` is when the clip was last opened in the player (#16). Unlike the
+   `practised` stamp it replaces, this one is **produced as well as seeded** —
+   opening a clip below really does stamp it, so the chip can be driven here
+   rather than only looked at. The seed is the starting position, and it runs
+   counter to both `added` and `loops` on purpose: the clip added most recently
+   was last opened a week ago, and two have never been opened at all. That is
    the whole argument for the chip, and it is only visible in data that
    disagrees with the other three. */
 const SEED_CLIPS = [
@@ -21,7 +22,7 @@ const SEED_CLIPS = [
     added: '2026-08-29',
     seconds: 26,
     loops: 5,
-    practised: '2026-08-30T11:20:00.000Z',
+    opened: '2026-08-30T11:20:00.000Z',
     src: '/sample.mp4',
   },
   {
@@ -30,7 +31,7 @@ const SEED_CLIPS = [
     added: '2026-08-27',
     seconds: 18,
     loops: 2,
-    practised: '2026-09-06T18:04:11.000Z',
+    opened: '2026-09-06T18:04:11.000Z',
   },
   { id: 3, name: 'Clip 3', added: '2026-08-24', seconds: 41, loops: 0 },
   {
@@ -39,7 +40,7 @@ const SEED_CLIPS = [
     added: '2026-08-19',
     seconds: 12,
     loops: 3,
-    practised: '2026-09-05T20:00:00.000Z',
+    opened: '2026-09-05T20:00:00.000Z',
   },
   {
     id: 5,
@@ -47,7 +48,7 @@ const SEED_CLIPS = [
     added: '2026-08-11',
     seconds: 33,
     loops: 1,
-    practised: '2026-08-12T09:15:00.000Z',
+    opened: '2026-08-12T09:15:00.000Z',
   },
   { id: 6, name: 'Clip 6', added: '2026-08-04', seconds: 24, loops: 0 },
 ]
@@ -58,6 +59,10 @@ const SEED_CLIPS = [
 function App() {
   const [clips, setClips] = useState(SEED_CLIPS)
   const [clip, setClip] = useState(null)
+  /* Above the two screens, because the grid is unmounted while the player is up
+     and **Last opened** is a chip you pick *before* opening a clip and want to
+     still be on when you come back (#16). */
+  const [sort, setSort] = useState('added')
 
   const addClip = (added) => setClips([added, ...clips])
 
@@ -75,9 +80,25 @@ function App() {
   return (
     <Library
       clips={clips}
+      sort={sort}
+      onSort={setSort}
       onAdd={addClip}
       onDelete={deleteClip}
-      onOpen={(chosen) => setClip({ ...chosen, src: chosen.src ?? '/sample.mp4' })}
+      /* Stamped on the way in, which is the whole of the feature (#16): open a
+         clip, go back, and it is top of the grid under **Last opened**. In the
+         product the stamp goes to this device's own storage and rides the next
+         `loops.json` write to Drive; here there is neither, and the list held
+         above is the equivalent. */
+      onOpen={(chosen) => {
+        const at = new Date().toISOString()
+
+        setClips((held) =>
+          held.map((clip) =>
+            clip.id === chosen.id ? { ...clip, opened: at } : clip,
+          ),
+        )
+        setClip({ ...chosen, src: chosen.src ?? '/sample.mp4' })
+      }}
     />
   )
 }

--- a/mockup/src/Library.jsx
+++ b/mockup/src/Library.jsx
@@ -1,13 +1,16 @@
 import { useEffect, useRef, useState } from 'react'
 
-/* Retrofitted from the product (#12) — the mockup gate pass for a chip that was
-   built before anything had drawn it.
+/* Recent is the day a clip was uploaded and never changes again, so it cannot
+   answer "what am I working on". Last opened can, and it moves on the one action
+   a practice session is mostly made of: open a clip, watch it, go back.
 
-   Recent is the day a clip was uploaded and never changes again, so it cannot
-   answer "what am I working on". Last practised can. A clip never practised
-   compares as the empty string, which puts the whole never-practised tail below
-   every clip that has been — and still draws it, because a clip vanishing from
-   the grid under one chip would read as a clip deleted.
+   It **replaces** Last practised (#12, #16) rather than joining it. That chip
+   stamped a clip only when a loop was saved on it or removed from it — a rare
+   enough event that the ordering seldom moved.
+
+   A clip never opened compares as the empty string, which puts the whole
+   never-opened tail below every clip that has been — and still draws it, because
+   a clip vanishing from the grid under one chip would read as a clip deleted.
 
    Last of the four so that `SORTS[0]` stays Recent: it is the default, and it
    is where the grid jumps back to after an add. */
@@ -16,9 +19,9 @@ const SORTS = [
   { id: 'name', label: 'Name', compare: (a, b) => a.name.localeCompare(b.name) },
   { id: 'loops', label: 'Most looped', compare: (a, b) => b.loops - a.loops },
   {
-    id: 'practised',
-    label: 'Last practised',
-    compare: (a, b) => (b.practised ?? '').localeCompare(a.practised ?? ''),
+    id: 'opened',
+    label: 'Last opened',
+    compare: (a, b) => (b.opened ?? '').localeCompare(a.opened ?? ''),
   },
 ]
 
@@ -214,8 +217,13 @@ function DriveStatus() {
    is the only thing a mockup is for. */
 const UPLOAD_PLAYS_OUT_OVER = 2500
 
-function Library({ clips, onOpen, onAdd, onDelete }) {
-  const [sort, setSort] = useState(SORTS[0].id)
+/* `sort` is held by the caller rather than here, and that is load-bearing for
+   #16 rather than tidiness: this screen is unmounted while the player is up, so
+   local state would start over at Recent every time the dancer came back — and
+   **Last opened** is a chip whose whole point is what you see *after* a trip
+   through the player. Picking it, opening a clip and returning to Recent would
+   make the ordering unreachable in the one moment it is for. */
+function Library({ clips, sort, onSort, onOpen, onAdd, onDelete }) {
   const [notice, setNotice] = useState(null)
   const [uploading, setUploading] = useState({})
   /* The library comes out of Drive in the product, so there is a moment before
@@ -319,7 +327,7 @@ function Library({ clips, onOpen, onAdd, onDelete }) {
         loops: 0,
         src,
       })
-      setSort('added')
+      onSort('added')
       playOutAnUpload(id)
     }
   }
@@ -358,7 +366,7 @@ function Library({ clips, onOpen, onAdd, onDelete }) {
             <button
               key={option.id}
               type="button"
-              onClick={() => setSort(option.id)}
+              onClick={() => onSort(option.id)}
               className={`rounded-full px-3 py-1 text-xs font-semibold ${
                 option.id === sort
                   ? 'bg-control-hi text-ink'


### PR DESCRIPTION
Closes #16. Supersedes #12 / !15.

**Last practised** stamped a clip only when a loop was saved on it or removed
from it — rare enough that the ordering seldom moved. This replaces it with the
action a practice session is mostly made of: open a clip, watch it, go back, and
it is top of the grid.

## Where the stamp lives

On the **device**, in `localStorage`, written the moment the clip opens.

Opening a clip is the commonest thing the app does. A `loops.json` write per open
would be four Drive calls each time, aimed at the one file that holds the loops,
and each one another chance at the `moved` / `unreadable` refusal — a refusal the
dancer has to be told about. Paying that for an ordering is the wrong way round:
recency is not the asset.

So the stamps ride the write a loop save or removal was *already* making.
`withOpens` folds them in inside the change `applyToLoops` replays, so a retry
carries them and they merge exactly as the loops do. The grid reads the later of
this device's record and Drive's, because either may be ahead.

The accepted consequence: a device that only ever browses and never saves a loop
does not publish its opens. Locally it is always correct and instant, which is
the moment the chip is for.

`touched` keeps its key name and `schema` stays at **1**, so no `loops.json`
already in Drive becomes unreadable and no migration is needed.

## A bug the mockup pass caught

Driving the mockup first — as the process asks, and as #12 did not — turned up
something the ticket had not: **the grid reset to Recent on every return from the
player.** `ClipsScreen` held the chosen ordering in its own state and React Router
unmounts it on `/clip/:clipId`, so picking **Last opened**, opening a clip and
coming back put you back on Recent. That makes this chip unreachable in the exact
moment it exists for.

The ordering moves up to `App`, beside the library and the loops, for the reason
they are already there. Pinned by `"is still the chosen ordering after a trip
through the player"`.

## Shape

Substitutive, and the halves are separate commits so the net is honest:

- **Reduction** — `withClip` / `withLoop` / `withoutLoop` stop taking a clock and
  stop stamping; `useLoops` stops reading one. The behaviour's own tests are the
  RED: they come out, the suite stays green, net **-8** cases. Nothing was added
  asserting the old behaviour is gone.
- **Addition** — `openedStore` (11 cases), `withOpens` / `laterOf` (9), and seven
  at `App`, which is where the feature lives because it only exists across a
  round trip that each component sees half of.

Net **+27** cases across the branch.

## Verification

`node scripts/verify.mjs` — **GATE: PASS**, 7 checks ran, all green; 5 skipped
(pre-existing: no `test`/`typecheck` in `mockup`, no `build`/`lint`/`typecheck`
at the root). 686 tests.

Not driven against real Drive. The `drive.file` scope, the OAuth popup and the
token renewal are untouched by this, and the cross-device merge is exercised as
a replay rather than on two actual devices.

## Mockup gate pass

`mockup/src/Library.jsx` and `App.jsx` carry the same chip, and the mockup now
**produces** the stamp rather than only seeding it — opening a clip there really
does stamp it, so the chip can be driven instead of looked at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gZfpvFyvGK93DkmjYVuBS
