### PR TITLE
#21 a scrubber on the video, scaled to the loop

### DIFF
--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -2346,11 +2346,9 @@ describe('the loops this clip already had', () => {
 /* #21. Where you are in the clip, drawn on the clip — the video carried no
    position indicator at all before this, no `controls` and nothing of our own,
    so it simply played blind. */
-const scrubTrack = (container: HTMLElement) =>
-  container.querySelector('.scrub-track')
+const scrubTrack = () => document.querySelector('.scrub-track')
 
-const scrubFill = (container: HTMLElement) =>
-  container.querySelector('.scrub-fill')
+const scrubFill = () => document.querySelector('.scrub-fill')
 
 const seekForward = () =>
   fireEvent.click(screen.getByRole('button', { name: 'Forward 1 second' }))
@@ -2372,12 +2370,11 @@ describe('the position bar on the clip', () => {
   })
 
   it('fills the bar to where the playhead is', () => {
-    const { container } = renderPlayer(getClip({ src: '/wave-practice.mp4' }))
+    aReadyClip({ seconds: 20 })
 
-    fireEvent.loadedMetadata(playable(clipSurface(container), { seconds: 20 }))
     seekForward()
 
-    expect(scrubFill(container)).toHaveStyle({ width: '5%' })
+    expect(scrubFill()).toHaveStyle({ width: '5%' })
   })
 
   it('says the time the playhead moved to', () => {
@@ -2392,9 +2389,9 @@ describe('the position bar on the clip', () => {
      no length to lay a bar out against, and a bar spanning an unknown clip would
      be inviting a drag against nothing. */
   it('draws no bar until the clip has a length', () => {
-    const { container } = renderPlayer(getClip({ src: '/wave-practice.mp4' }))
+    renderPlayer(getClip({ src: '/wave-practice.mp4' }))
 
-    expect(scrubTrack(container)).toBeNull()
+    expect(scrubTrack()).toBeNull()
   })
 
   /* The reason it rides inside the video wrapper rather than under the card:
@@ -2406,7 +2403,76 @@ describe('the position bar on the clip', () => {
     fireEvent.loadedMetadata(playable(clipSurface(container), { seconds: 12 }))
     fireEvent.click(screen.getByRole('button', { name: 'Isolate the video' }))
 
-    expect(scrubTrack(container)).toBeInTheDocument()
+    expect(scrubTrack()).toBeInTheDocument()
     expect(screen.getByText('0:00 / 0:12')).toBeVisible()
+  })
+})
+
+/* The rescale, which is the whole reason this bar is not the loop slider: a
+   six-second loop in a 2:28 clip is 4% of the slider's width, and the tighter the
+   loop the worse it gets — backwards, because a tight loop is exactly when you
+   most need to move inside it. */
+const aClipLoopingPartOfIt = ({ seconds = 12, a = 2, b = 6 } = {}) => {
+  const clip = aReadyClip({ seconds })
+
+  clip.currentTime = a
+  press('Space')
+  clip.currentTime = b
+  press('Space')
+
+  return clip
+}
+
+const releaseTheLoop = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'LOOPING' }))
+
+/* Space marks a boundary off the element's own `currentTime`, which React never
+   hears about — so a playhead put there by hand draws at zero. These two move it
+   through the controls the dancer would use, which is what makes the drawn
+   position real. */
+const toStartOfLoop = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'START' }))
+
+describe('the position bar once a loop is armed', () => {
+  it('labels its ends with the two times it spans', () => {
+    aClipLoopingPartOfIt({ a: 2, b: 6 })
+
+    expect(screen.getByText('0:02 – 0:06')).toBeInTheDocument()
+  })
+
+  /* The bar is full at B, not four-twelfths along at the end of the clip. This
+     and the test below it are one assertion in two halves: the same playhead, the
+     same clip, and a different reading the moment the loop stops penning it in. */
+  it('fills against the loop rather than against the clip', () => {
+    aClipLoopingPartOfIt({ seconds: 20, a: 4, b: 6 })
+
+    toStartOfLoop()
+    seekForward()
+
+    expect(scrubFill()).toHaveStyle({ width: '50%' })
+  })
+
+  it('reads the same playhead against the whole clip once the loop is released', () => {
+    aClipLoopingPartOfIt({ seconds: 20, a: 4, b: 6 })
+
+    toStartOfLoop()
+    seekForward()
+    releaseTheLoop()
+
+    expect(scrubFill()).toHaveStyle({ width: '25%' })
+  })
+
+  it('says nothing about a range while the loop is the whole clip', () => {
+    aReadyClip({ seconds: 12 })
+
+    expect(screen.queryByText(/–/)).toBeNull()
+  })
+
+  it('drops the range label when the loop is released', () => {
+    aClipLoopingPartOfIt({ a: 2, b: 6 })
+
+    releaseTheLoop()
+
+    expect(screen.queryByText('0:02 – 0:06')).toBeNull()
   })
 })

--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -2342,3 +2342,71 @@ describe('the loops this clip already had', () => {
     expect(nameField()).toHaveAttribute('placeholder', 'Loop 2')
   })
 })
+
+/* #21. Where you are in the clip, drawn on the clip — the video carried no
+   position indicator at all before this, no `controls` and nothing of our own,
+   so it simply played blind. */
+const scrubTrack = (container: HTMLElement) =>
+  container.querySelector('.scrub-track')
+
+const scrubFill = (container: HTMLElement) =>
+  container.querySelector('.scrub-fill')
+
+const seekForward = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Forward 1 second' }))
+
+describe('the position bar on the clip', () => {
+  it('writes the elapsed and total time on the clip', () => {
+    aReadyClip({ seconds: 12 })
+
+    expect(screen.getByText('0:00 / 0:12')).toBeInTheDocument()
+  })
+
+  /* Written with `formatDuration` like every other length on this screen, rather
+     than the mockup's own spelling — the player should not write a time
+     differently from the tile it was opened from. */
+  it('writes a longer clip the way the grid writes lengths', () => {
+    aReadyClip({ seconds: 148 })
+
+    expect(screen.getByText('0:00 / 2:28')).toBeInTheDocument()
+  })
+
+  it('fills the bar to where the playhead is', () => {
+    const { container } = renderPlayer(getClip({ src: '/wave-practice.mp4' }))
+
+    fireEvent.loadedMetadata(playable(clipSurface(container), { seconds: 20 }))
+    seekForward()
+
+    expect(scrubFill(container)).toHaveStyle({ width: '5%' })
+  })
+
+  it('says the time the playhead moved to', () => {
+    aReadyClip({ seconds: 20 })
+
+    seekForward()
+
+    expect(screen.getByText('0:01 / 0:20')).toBeInTheDocument()
+  })
+
+  /* Gated exactly as the slider and the transport are. Before metadata there is
+     no length to lay a bar out against, and a bar spanning an unknown clip would
+     be inviting a drag against nothing. */
+  it('draws no bar until the clip has a length', () => {
+    const { container } = renderPlayer(getClip({ src: '/wave-practice.mp4' }))
+
+    expect(scrubTrack(container)).toBeNull()
+  })
+
+  /* The reason it rides inside the video wrapper rather than under the card:
+     zen hides the whole control strip, so this is the only thing left that says
+     where the clip has got to — and that is where it matters most. */
+  it('stays on the clip in zen, where the control strip is not', () => {
+    const { container } = renderPlayer(getClip({ src: '/wave-practice.mp4' }))
+
+    fireEvent.loadedMetadata(playable(clipSurface(container), { seconds: 12 }))
+    fireEvent.click(screen.getByRole('button', { name: 'Isolate the video' }))
+
+    expect(scrubTrack(container)).toBeInTheDocument()
+    expect(screen.getByText('0:00 / 0:12')).toBeVisible()
+  })
+})

--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -2476,3 +2476,91 @@ describe('the position bar once a loop is armed', () => {
     expect(screen.queryByText('0:02 – 0:06')).toBeNull()
   })
 })
+
+/* A drag reads where the pointer landed against the width of the bar, and jsdom
+   lays nothing out — so the bar has to be given a size first, exactly as the loop
+   track is. 200px makes every position a round number. */
+const aLaidOutBar = ({ width = 200 } = {}) => {
+  const bar = scrubTrack()
+
+  if (!bar) throw new Error('The player drew no position bar')
+
+  return laidOut(bar, { width })
+}
+
+const scrubAt = (clientX: number) =>
+  fireEvent.pointerDown(aLaidOutBar(), { pointerId: 1, clientX })
+
+describe('scrubbing the position bar', () => {
+  it('seeks to where the bar was touched', () => {
+    const clip = aReadyClip({ seconds: 12 })
+
+    scrubAt(100)
+
+    expect(clip.currentTime).toBe(6)
+  })
+
+  /* The same pixel, a different moment. Halfway along a bar spanning the whole
+     12s clip is 6s; halfway along one spanning a 4-to-6 loop is 5s — which is the
+     rescale doing its work through the real screen rather than in arithmetic. */
+  it('seeks within the loop once the bar spans one', () => {
+    const clip = aClipLoopingPartOfIt({ seconds: 20, a: 4, b: 6 })
+
+    scrubAt(100)
+
+    expect(clip.currentTime).toBe(5)
+  })
+
+  /* Criterion four. There is nothing clamping here — the far end of the bar *is*
+     B, so a drag that carries on past it has nowhere further to go. */
+  it('travels exactly the loop and no further', () => {
+    const clip = aClipLoopingPartOfIt({ seconds: 20, a: 4, b: 6 })
+
+    /* Off A first, or the assertion below is satisfied by the playhead space
+       already left at B and says nothing about the drag. */
+    toStartOfLoop()
+    scrubAt(900)
+
+    expect(clip.currentTime).toBe(6)
+  })
+
+  it('follows the pointer as the drag moves', () => {
+    const clip = aReadyClip({ seconds: 12 })
+
+    fireEvent.pointerDown(aLaidOutBar(), { pointerId: 1, clientX: 50 })
+    fireEvent.pointerMove(aLaidOutBar(), { pointerId: 1, clientX: 150 })
+
+    expect(clip.currentTime).toBe(9)
+  })
+
+  /* A move with no drag behind it is a mouse passing over the bar on its way
+     somewhere else. Seeking on that would make the clip jump whenever the pointer
+     crossed the video. */
+  it('ignores a pointer merely passing over it', () => {
+    const clip = aReadyClip({ seconds: 12 })
+
+    fireEvent.pointerMove(aLaidOutBar(), { pointerId: 1, clientX: 150 })
+
+    expect(clip.currentTime).toBe(0)
+  })
+
+  /* The separation the loop track already keeps, kept here too: scrubbing and
+     framing are different acts, and a bar that dragged a boundary along with the
+     playhead would destroy the loop every time the dancer looked elsewhere. */
+  it('never moves A or B', () => {
+    aClipLoopingPartOfIt({ seconds: 20, a: 4, b: 6 })
+
+    scrubAt(20)
+
+    expect(boundary('Loop start')).toHaveAttribute('aria-valuenow', '4')
+    expect(boundary('Loop end')).toHaveAttribute('aria-valuenow', '6')
+  })
+
+  it('draws the playhead where the drag left it', () => {
+    aReadyClip({ seconds: 20 })
+
+    scrubAt(50)
+
+    expect(scrubFill()).toHaveStyle({ width: '25%' })
+  })
+})

--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -2564,3 +2564,76 @@ describe('scrubbing the position bar', () => {
     expect(scrubFill()).toHaveStyle({ width: '25%' })
   })
 })
+
+/* BR-19 again, and the one piece of behaviour the mockup left for the app to
+   settle. Dragging to the far end of a rescaled bar lands exactly on B, and
+   enforcement fires on `currentTime >= b` — so the playhead would jump to A
+   while the finger is still at the right-hand edge, and the fill would snap to
+   empty under it. The drag and enforcement are the same clip pulled two ways,
+   which is precisely the fight a held handle already stands enforcement down
+   for. */
+describe('scrubbing while the loop runs', () => {
+  const aRunningLoop = () => {
+    const clip = aClipLoopingPartOfIt({ seconds: 20, a: 4, b: 6 })
+
+    /* Off B first: space left the playhead there, and enforcement would send it
+       to A on the first frame of playback before the drag happened at all. */
+    toStartOfLoop()
+    fireEvent.play(clip)
+
+    return clip
+  }
+
+  it('stays where the drag reached rather than restarting the loop', () => {
+    vi.useFakeTimers()
+    const clip = aRunningLoop()
+
+    scrubAt(900)
+    act(() => vi.advanceTimersByTime(A_FEW_FRAMES))
+
+    expect(clip.currentTime).toBe(6)
+  })
+
+  /* Standing down lasts the length of the drag and no longer. Letting go is the
+     dancer saying they are done moving about, and the loop they were listening
+     to is what they want back — so landing on B and releasing wraps to A, which
+     is the loop doing its job rather than fighting the finger. */
+  it('takes the loop back up as soon as the drag ends', () => {
+    vi.useFakeTimers()
+    const clip = aRunningLoop()
+    const bar = aLaidOutBar()
+
+    fireEvent.pointerDown(bar, { pointerId: 1, clientX: 900 })
+    fireEvent.pointerUp(bar, { pointerId: 1 })
+    act(() => vi.advanceTimersByTime(A_FEW_FRAMES))
+
+    expect(clip.currentTime).toBe(4)
+  })
+
+  /* A drag that leaves the window never sees its own pointer-up. Without this
+     the loop would stay stood down for the rest of the session, and the dancer
+     would have a clip that quietly stopped looping. */
+  it('takes the loop back up when the drag is cancelled', () => {
+    vi.useFakeTimers()
+    const clip = aRunningLoop()
+    const bar = aLaidOutBar()
+
+    fireEvent.pointerDown(bar, { pointerId: 1, clientX: 900 })
+    fireEvent.pointerCancel(bar, { pointerId: 1 })
+    act(() => vi.advanceTimersByTime(A_FEW_FRAMES))
+
+    expect(clip.currentTime).toBe(4)
+  })
+
+  /* Scrubbing to somewhere inside the loop is the ordinary case, and it must
+     keep playing from there rather than being pulled anywhere. */
+  it('plays on from a scrub that lands inside the loop', () => {
+    vi.useFakeTimers()
+    const clip = aRunningLoop()
+
+    scrubAt(100)
+    act(() => vi.advanceTimersByTime(A_FEW_FRAMES))
+
+    expect(clip.currentTime).toBe(5)
+  })
+})

--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -2637,3 +2637,31 @@ describe('scrubbing while the loop runs', () => {
     expect(clip.currentTime).toBe(5)
   })
 })
+
+/* Three facts this suite cannot actually check. jsdom implements neither
+   `pointer-events` nor `touch-action`, and it has no notion of how big a thumb
+   is — so what follows asserts that the classes carrying them are *present*, not
+   that they work. It is a guard against them being dropped in a refactor, and
+   the real check is a smoke test on a phone.
+
+   Said once, as one test, rather than spread over three that would read like
+   behavioural coverage of the criteria they stand in for. */
+describe('the position bar under a thumb', () => {
+  it('keeps the classes the phone depends on', () => {
+    aReadyClip({ seconds: 12 })
+
+    const strip = scrubTrack()
+
+    /* A drag down the bottom of a video is otherwise a page scroll. */
+    expect(strip).toHaveClass('touch-none')
+    /* A 2px line is not a touch target: the line stays hairline and the strip
+       around it is padded to something a thumb can find. */
+    expect(strip).toHaveClass('py-3')
+    /* The scrim is a tall gradient over the bottom of the frame, and the video
+       under it is the play/pause target — so it takes no pointer events and only
+       the strip takes them back. Without this, tapping the clip to pause it
+       would stop working wherever the bar happens to be. */
+    expect(strip).toHaveClass('pointer-events-auto')
+    expect(strip?.parentElement).toHaveClass('pointer-events-none')
+  })
+})

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -32,6 +32,7 @@ import {
   StartGlyph,
   TransportButton,
 } from './TransportButton'
+import { VideoProgress } from './VideoProgress'
 
 /* Asked of the element every time, rather than of a flag the screen keeps.
    Playback stops for reasons the app never hears about — the clip ends, the phone
@@ -708,6 +709,21 @@ function OpenedClip({
                   void surface.current?.play()
                 }}
               />
+
+              {/* Gated on a ready clip like the slider and the transport: before
+                  metadata there is no length to lay a bar out against, and a bar
+                  spanning an unknown clip would invite a drag against nothing.
+                  Inside this wrapper rather than in the strip below, which is
+                  what carries it through zen. */}
+              {playback.kind === 'ready' && (
+                <VideoProgress
+                  time={time}
+                  duration={playback.duration}
+                  loop={playback.loop}
+                  looping={playback.looping}
+                  rounded={isolated ? undefined : 'rounded-b-lg'}
+                />
+              )}
 
               {/* On the video itself, so a dancer who does not know the
                   shortcut is not trapped once the controls are gone. It is one

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -721,6 +721,7 @@ function OpenedClip({
                   duration={playback.duration}
                   loop={playback.loop}
                   looping={playback.looping}
+                  onScrub={seekTo}
                   rounded={isolated ? undefined : 'rounded-b-lg'}
                 />
               )}

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -722,6 +722,7 @@ function OpenedClip({
                   loop={playback.loop}
                   looping={playback.looping}
                   onScrub={seekTo}
+                  onHold={setAdjusting}
                   rounded={isolated ? undefined : 'rounded-b-lg'}
                 />
               )}

--- a/app/src/player/VideoProgress.tsx
+++ b/app/src/player/VideoProgress.tsx
@@ -109,7 +109,12 @@ export function VideoProgress({
           in every test that drags. */}
       <div
         ref={track}
-        className="scrub-track group pointer-events-auto -my-3 cursor-pointer py-3"
+        /* A 2px line is not a touch target. The padding gives a thumb ~28px to
+           land in while the line itself stays hairline, and the negative margin
+           keeps that height from pushing the bar off the bottom of the frame.
+           `touch-none` is the other half: without it a drag down the bottom of a
+           video is read as a page scroll and the bar never sees it. */
+        className="scrub-track group pointer-events-auto -my-3 cursor-pointer touch-none py-3"
         onPointerDown={(event) => {
           event.currentTarget.setPointerCapture?.(event.pointerId)
           grab()

--- a/app/src/player/VideoProgress.tsx
+++ b/app/src/player/VideoProgress.tsx
@@ -37,10 +37,23 @@ export function VideoProgress({
     <div
       className={`absolute inset-x-0 bottom-0 select-none bg-gradient-to-t from-black/70 to-transparent px-2 pb-2 pt-8 ${rounded ?? ''}`}
     >
-      {/* Where you actually are, absolute rather than relative to the span — it
-          is the number you came for, and a rescaled bar must not change what the
-          clock says. */}
-      <div className="mb-1.5 flex items-baseline justify-end gap-2">
+      {/* Two facts, and the row has room for both.
+
+          Left: what the bar spans, shown only once that is no longer the whole
+          clip. It is what carries the rescale, which is otherwise abrupt and
+          invisible — the bar's meaning changes in a single frame, and without
+          this a playhead sitting mid-bar at 1:03 of a 2:28 clip simply looks
+          wrong.
+
+          Right: where you actually are, absolute rather than relative to the
+          span. That is the number you came for, and a rescaled bar must not
+          change what the clock says. */}
+      <div className="mb-1.5 flex items-baseline justify-between gap-2">
+        <span className="text-[11px] tabular-nums text-white/60 drop-shadow">
+          {span.rescaled
+            ? `${formatDuration(span.from)} – ${formatDuration(span.to)}`
+            : ''}
+        </span>
         <span className="text-[11px] tabular-nums text-white/80 drop-shadow">
           {formatDuration(time)} / {formatDuration(duration)}
         </span>

--- a/app/src/player/VideoProgress.tsx
+++ b/app/src/player/VideoProgress.tsx
@@ -23,6 +23,7 @@ export function VideoProgress({
   loop,
   looping,
   onScrub,
+  onHold,
   rounded,
 }: {
   readonly time: number
@@ -30,6 +31,15 @@ export function VideoProgress({
   readonly loop: Loop
   readonly looping: boolean
   readonly onScrub: (seconds: number) => void
+  /* BR-19, reaching the second surface that can pull the playhead. Dragging to
+     the far end of a rescaled bar lands exactly on B, and enforcement fires on
+     `currentTime >= b` — so without this the clip jumps to A while the finger is
+     still at the right-hand edge and the fill snaps to empty underneath it.
+
+     The mockup left this open, and it is settled the way a held handle already
+     settles it: the clip genuinely is at B, it was put there on purpose, and no
+     reading of `currentTime` can tell that apart from having arrived. */
+  readonly onHold: (held: boolean) => void
   /* Follows the clip's own corners, so the scrim does not square off a rounded
      video. Zen has no rounding to follow. */
   readonly rounded?: string | undefined
@@ -48,6 +58,20 @@ export function VideoProgress({
         span,
       }),
     )
+
+  /* Both edges of the window in one place, beside the state already tracking the
+     drag, so the hold and the drag cannot come to different answers about
+     whether the dancer has hold of the playhead — the arrangement `LoopSlider`
+     uses for the same reason. */
+  const grab = () => {
+    setDragging(true)
+    onHold(true)
+  }
+
+  const letGo = () => {
+    setDragging(false)
+    onHold(false)
+  }
 
   return (
     /* `pointer-events-none` on the whole scrim, taken back only by the grab
@@ -88,7 +112,7 @@ export function VideoProgress({
         className="scrub-track group pointer-events-auto -my-3 cursor-pointer py-3"
         onPointerDown={(event) => {
           event.currentTarget.setPointerCapture?.(event.pointerId)
-          setDragging(true)
+          grab()
           scrubTo(event.clientX)
         }}
         /* A move with no drag behind it is a mouse passing over the bar on its
@@ -99,9 +123,11 @@ export function VideoProgress({
         }}
         onPointerUp={(event) => {
           event.currentTarget.releasePointerCapture?.(event.pointerId)
-          setDragging(false)
+          letGo()
         }}
-        onPointerCancel={() => setDragging(false)}
+        /* A drag that leaves the window never sees its own pointer-up, and a
+           loop left stood down would be a clip that quietly stopped looping. */
+        onPointerCancel={letGo}
       >
         <div
           className={`relative w-full rounded-full bg-white/20 transition-[height] ${

--- a/app/src/player/VideoProgress.tsx
+++ b/app/src/player/VideoProgress.tsx
@@ -1,0 +1,59 @@
+import { formatDuration } from '../clips/format'
+import type { Loop } from './playback'
+import { ratioOf, spanned } from './scrubSpan'
+
+/* Where you are in the clip, drawn on the clip itself. The video carried no
+   position indicator at all before this — no `controls`, nothing of our own — so
+   it played blind.
+
+   It rides inside the video wrapper rather than under the card, which is what
+   makes it survive zen: the whole control strip is hidden there, so this is the
+   only thing left saying where the clip has got to, and that is the case it
+   matters most in.
+
+   Deliberately not a second loop slider. The two answer different questions
+   about the same timeline — that one is "which few seconds am I working on",
+   this one is "where am I" — and neither can do the other's job. Nothing here
+   touches A or B. */
+export function VideoProgress({
+  time,
+  duration,
+  loop,
+  looping,
+  rounded,
+}: {
+  readonly time: number
+  readonly duration: number
+  readonly loop: Loop
+  readonly looping: boolean
+  /* Follows the clip's own corners, so the scrim does not square off a rounded
+     video. Zen has no rounding to follow. */
+  readonly rounded?: string | undefined
+}) {
+  const span = spanned({ loop, looping, duration })
+  const at = `${ratioOf(time, span) * 100}%`
+
+  return (
+    <div
+      className={`absolute inset-x-0 bottom-0 select-none bg-gradient-to-t from-black/70 to-transparent px-2 pb-2 pt-8 ${rounded ?? ''}`}
+    >
+      {/* Where you actually are, absolute rather than relative to the span — it
+          is the number you came for, and a rescaled bar must not change what the
+          clock says. */}
+      <div className="mb-1.5 flex items-baseline justify-end gap-2">
+        <span className="text-[11px] tabular-nums text-white/80 drop-shadow">
+          {formatDuration(time)} / {formatDuration(duration)}
+        </span>
+      </div>
+
+      <div className="scrub-track py-3">
+        <div className="relative h-0.5 w-full rounded-full bg-white/20">
+          <div
+            className="scrub-fill absolute inset-y-0 left-0 rounded-full bg-white"
+            style={{ width: at }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/player/VideoProgress.tsx
+++ b/app/src/player/VideoProgress.tsx
@@ -1,6 +1,8 @@
+import { useRef, useState } from 'react'
+
 import { formatDuration } from '../clips/format'
 import type { Loop } from './playback'
-import { ratioOf, spanned } from './scrubSpan'
+import { ratioOf, secondsAt, spanned } from './scrubSpan'
 
 /* Where you are in the clip, drawn on the clip itself. The video carried no
    position indicator at all before this — no `controls`, nothing of our own — so
@@ -20,22 +22,40 @@ export function VideoProgress({
   duration,
   loop,
   looping,
+  onScrub,
   rounded,
 }: {
   readonly time: number
   readonly duration: number
   readonly loop: Loop
   readonly looping: boolean
+  readonly onScrub: (seconds: number) => void
   /* Follows the clip's own corners, so the scrim does not square off a rounded
      video. Zen has no rounding to follow. */
   readonly rounded?: string | undefined
 }) {
+  const track = useRef<HTMLDivElement>(null)
+  const [dragging, setDragging] = useState(false)
+
   const span = spanned({ loop, looping, duration })
   const at = `${ratioOf(time, span) * 100}%`
 
+  const scrubTo = (clientX: number) =>
+    onScrub(
+      secondsAt({
+        clientX,
+        track: track.current?.getBoundingClientRect() ?? { left: 0, width: 0 },
+        span,
+      }),
+    )
+
   return (
+    /* `pointer-events-none` on the whole scrim, taken back only by the grab
+       strip below. The video surface is the play/pause target, so a bar owning
+       the bottom of the frame would cost the dancer tapping the clip to pause
+       it — and the scrim is a good deal taller than the line it draws. */
     <div
-      className={`absolute inset-x-0 bottom-0 select-none bg-gradient-to-t from-black/70 to-transparent px-2 pb-2 pt-8 ${rounded ?? ''}`}
+      className={`pointer-events-none absolute inset-x-0 bottom-0 select-none bg-gradient-to-t from-black/70 to-transparent px-2 pb-2 pt-8 ${rounded ?? ''}`}
     >
       {/* Two facts, and the row has room for both.
 
@@ -59,11 +79,44 @@ export function VideoProgress({
         </span>
       </div>
 
-      <div className="scrub-track py-3">
-        <div className="relative h-0.5 w-full rounded-full bg-white/20">
+      {/* Capture keeps the drag alive when the finger slides off the strip, as
+          it does on the loop handles — and optional-called for their reason too,
+          because jsdom implements no pointer capture and a bare call would throw
+          in every test that drags. */}
+      <div
+        ref={track}
+        className="scrub-track group pointer-events-auto -my-3 cursor-pointer py-3"
+        onPointerDown={(event) => {
+          event.currentTarget.setPointerCapture?.(event.pointerId)
+          setDragging(true)
+          scrubTo(event.clientX)
+        }}
+        /* A move with no drag behind it is a mouse passing over the bar on its
+           way somewhere else; seeking on that would make the clip jump whenever
+           the pointer crossed the video. */
+        onPointerMove={(event) => {
+          if (dragging) scrubTo(event.clientX)
+        }}
+        onPointerUp={(event) => {
+          event.currentTarget.releasePointerCapture?.(event.pointerId)
+          setDragging(false)
+        }}
+        onPointerCancel={() => setDragging(false)}
+      >
+        <div
+          className={`relative w-full rounded-full bg-white/20 transition-[height] ${
+            dragging ? 'h-1' : 'h-0.5 group-hover:h-1'
+          }`}
+        >
           <div
             className="scrub-fill absolute inset-y-0 left-0 rounded-full bg-white"
             style={{ width: at }}
+          />
+          <div
+            className={`absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow transition-transform ${
+              dragging ? 'scale-100' : 'scale-0 group-hover:scale-100'
+            }`}
+            style={{ left: at }}
           />
         </div>
       </div>

--- a/app/src/player/loopRange.ts
+++ b/app/src/player/loopRange.ts
@@ -23,6 +23,23 @@ export type Track = {
 export const clamp = (value: number, min: number, max: number) =>
   Math.min(Math.max(value, min), max)
 
+/* How far along an element a pointer is, as a fraction. Both bars on this screen
+   ask this — the loop track against the clip, the position bar against whatever
+   it currently spans (`scrubSpan.ts`) — and they differ only in what they
+   multiply it by, so the reading itself is stated once.
+
+   A track that has not been laid out has no width, and dividing by it gives
+   Infinity — which would then be written to `currentTime`. Answering 0 makes
+   both callers land on the start of their own range without either needing a
+   case for it. */
+export const ratioAt = ({
+  clientX,
+  track,
+}: {
+  readonly clientX: number
+  readonly track: Track
+}) => (track.width <= 0 ? 0 : clamp((clientX - track.left) / track.width, 0, 1))
+
 export const timeAt = ({
   clientX,
   track,
@@ -31,11 +48,7 @@ export const timeAt = ({
   readonly clientX: number
   readonly track: Track
   readonly duration: number
-}) => {
-  if (track.width <= 0) return 0
-
-  return clamp((clientX - track.left) / track.width, 0, 1) * duration
-}
+}) => ratioAt({ clientX, track }) * duration
 
 /* The one place a boundary moves. The drag, the arrow keys and Home/End all come
    through here, so the floor and the clip's own bounds cannot be enforced on one

--- a/app/src/player/scrubSpan.test.ts
+++ b/app/src/player/scrubSpan.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Loop } from './playback'
+import { EDGE, spanned } from './scrubSpan'
+
+const aLoop = ({ a = 0, b = 12 }: Partial<Loop> = {}): Loop => ({ a, b })
+
+/* The rescale, and the whole reason this bar is not the loop slider. Six seconds
+   of a 2:28 clip is 4% of the width; spanning the loop instead makes the full
+   width buy you the loop, so a tighter loop scrubs finer rather than coarser. */
+describe('what the scrub bar spans', () => {
+  it('spans A to B when a loop is armed over part of the clip', () => {
+    expect(
+      spanned({ loop: aLoop({ a: 3, b: 9 }), looping: true, duration: 12 }),
+    ).toEqual({ from: 3, to: 9 })
+  })
+
+  /* The case that makes the rest of the clip reachable at all. With looping off
+     there is nothing penning the playhead in, so the bar has no reason to. */
+  it('spans the whole clip when looping is off', () => {
+    expect(
+      spanned({ loop: aLoop({ a: 3, b: 9 }), looping: false, duration: 12 }),
+    ).toEqual({ from: 0, to: 12 })
+  })
+
+  it('spans the whole clip when the loop already is the whole clip', () => {
+    expect(spanned({ loop: aLoop(), looping: true, duration: 12 })).toEqual({
+      from: 0,
+      to: 12,
+    })
+  })
+
+  /* Not fussiness. A and B arrive from a drag across real geometry, so B lands a
+     rounding error short of the duration about half the time — and an exact
+     comparison would leave the bar zoomed to 99.9% of the clip, which looks like
+     a bug and scrubs like one. */
+  it('counts a B a rounding error short of the end as the end', () => {
+    expect(
+      spanned({ loop: aLoop({ b: 12 - EDGE / 2 }), looping: true, duration: 12 }),
+    ).toEqual({ from: 0, to: 12 })
+  })
+
+  it('counts an A a rounding error past the start as the start', () => {
+    expect(
+      spanned({ loop: aLoop({ a: EDGE / 2 }), looping: true, duration: 12 }),
+    ).toEqual({ from: 0, to: 12 })
+  })
+
+  /* One end being meaningfully inside is enough to be penned in, so a loop that
+     runs from the middle to the very end still rescales. Asserted because the
+     natural reading — "both ends must be inside" — leaves the commonest loop of
+     all, the one trimmed only at the front, unscaled. */
+  it('spans a loop that reaches the end but starts well inside', () => {
+    expect(
+      spanned({ loop: aLoop({ a: 5, b: 12 }), looping: true, duration: 12 }),
+    ).toEqual({ from: 5, to: 12 })
+  })
+
+  /* Before metadata there is no clip to span. Answering 0..0 rather than
+     dividing by it is what keeps every ratio downstream finite. */
+  it('spans nothing while the clip has no length', () => {
+    expect(spanned({ loop: aLoop(), looping: true, duration: 0 })).toEqual({
+      from: 0,
+      to: 0,
+    })
+  })
+
+  /* A loop cannot be inverted through the slider — `movedTo` keeps B above A by
+     MIN_LOOP — but `spanned` is handed a loop rather than deriving one, and a
+     zero or negative span would put every ratio at infinity. */
+  it('spans the whole clip rather than an inverted loop', () => {
+    expect(
+      spanned({ loop: aLoop({ a: 9, b: 3 }), looping: true, duration: 12 }),
+    ).toEqual({ from: 0, to: 12 })
+  })
+})

--- a/app/src/player/scrubSpan.test.ts
+++ b/app/src/player/scrubSpan.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from 'vitest'
 
+import type { Track } from './loopRange'
 import type { Loop } from './playback'
-import { EDGE, spanned } from './scrubSpan'
+import { EDGE, ratioOf, secondsAt, type Span, spanned } from './scrubSpan'
 
 const aLoop = ({ a = 0, b = 12 }: Partial<Loop> = {}): Loop => ({ a, b })
+
+const aSpan = ({ from = 0, to = 12 }: Partial<Span> = {}): Span => ({ from, to })
+
+/* The two numbers of a `DOMRect` the arithmetic reads, for `loopRange`'s reason:
+   jsdom lays nothing out, so a real element answers 0 to every field and could
+   never be asked where a pointer landed. */
+const aTrack = ({ left = 0, width = 200 }: Partial<Track> = {}): Track => ({
+  left,
+  width,
+})
 
 /* The rescale, and the whole reason this bar is not the loop slider. Six seconds
    of a 2:28 clip is 4% of the width; spanning the loop instead makes the full
@@ -72,5 +83,85 @@ describe('what the scrub bar spans', () => {
     expect(
       spanned({ loop: aLoop({ a: 9, b: 3 }), looping: true, duration: 12 }),
     ).toEqual({ from: 0, to: 12 })
+  })
+})
+
+/* Where the fill and the thumb are drawn. A fraction of the span rather than of
+   the clip, which is what makes a rescaled bar draw the playhead in the right
+   place — at A the bar is empty and at B it is full, whatever the clip's length. */
+describe('where a moment sits along the bar', () => {
+  it('puts the start of the span at the left end', () => {
+    expect(ratioOf(3, aSpan({ from: 3, to: 9 }))).toBe(0)
+  })
+
+  it('puts the end of the span at the right end', () => {
+    expect(ratioOf(9, aSpan({ from: 3, to: 9 }))).toBe(1)
+  })
+
+  it('puts the middle of the span halfway along', () => {
+    expect(ratioOf(6, aSpan({ from: 3, to: 9 }))).toBe(0.5)
+  })
+
+  /* The playhead can be outside the span for a moment — the loop was just moved,
+     or looping was turned on while the clip was elsewhere. It parks at the end it
+     went past rather than being drawn off the bar. */
+  it('holds at the left end for a moment before the span', () => {
+    expect(ratioOf(1, aSpan({ from: 3, to: 9 }))).toBe(0)
+  })
+
+  it('holds at the right end for a moment after the span', () => {
+    expect(ratioOf(11, aSpan({ from: 3, to: 9 }))).toBe(1)
+  })
+
+  it('sits at the left end while the span has no width', () => {
+    expect(ratioOf(4, aSpan({ from: 0, to: 0 }))).toBe(0)
+  })
+})
+
+/* The same mapping read the other way: a pointer on the bar is a moment in the
+   span. Both directions live together because they are one relationship, and
+   splitting them is how they come to disagree. */
+describe('where a pointer on the bar lands in the clip', () => {
+  it('reads halfway along the bar as the middle of the span', () => {
+    expect(secondsAt({ clientX: 100, track: aTrack(), span: aSpan({ from: 3, to: 9 }) })).toBe(6)
+  })
+
+  /* The rescale, stated as arithmetic: the same pixel is a different moment
+     depending on what the bar spans. Halfway along a bar spanning a 6-second loop
+     inside a 2:28 clip is 25s of clip, not 74s. */
+  it('reads the same pixel differently once the bar spans a loop', () => {
+    expect(secondsAt({ clientX: 100, track: aTrack(), span: aSpan({ to: 148 }) })).toBe(74)
+    expect(
+      secondsAt({ clientX: 100, track: aTrack(), span: aSpan({ from: 22, to: 28 }) }),
+    ).toBe(25)
+  })
+
+  /* The bar is inside a video, inside a card, inside a padded main. A reading
+     that ignored the offset would land later in the clip than the dancer touched. */
+  it('measures from the bar rather than from the edge of the window', () => {
+    expect(
+      secondsAt({ clientX: 340, track: aTrack({ left: 240 }), span: aSpan({ from: 3, to: 9 }) }),
+    ).toBe(6)
+  })
+
+  it('holds at the start of the span when the drag goes off the left end', () => {
+    expect(
+      secondsAt({ clientX: -80, track: aTrack(), span: aSpan({ from: 3, to: 9 }) }),
+    ).toBe(3)
+  })
+
+  /* Criterion four, as arithmetic: dragging end to end travels exactly the loop
+     and no further. There is nothing to clamp against — a ratio cannot leave
+     0..1, so the span's own ends are the only places a drag can reach. */
+  it('holds at the end of the span when the drag goes off the right end', () => {
+    expect(
+      secondsAt({ clientX: 900, track: aTrack(), span: aSpan({ from: 3, to: 9 }) }),
+    ).toBe(9)
+  })
+
+  it('reads as the start of the span while the bar has no width', () => {
+    expect(
+      secondsAt({ clientX: 100, track: aTrack({ width: 0 }), span: aSpan({ from: 3, to: 9 }) }),
+    ).toBe(3)
   })
 })

--- a/app/src/player/scrubSpan.test.ts
+++ b/app/src/player/scrubSpan.test.ts
@@ -23,7 +23,7 @@ describe('what the scrub bar spans', () => {
   it('spans A to B when a loop is armed over part of the clip', () => {
     expect(
       spanned({ loop: aLoop({ a: 3, b: 9 }), looping: true, duration: 12 }),
-    ).toEqual({ from: 3, to: 9 })
+    ).toEqual({ from: 3, to: 9, rescaled: true })
   })
 
   /* The case that makes the rest of the clip reachable at all. With looping off
@@ -31,13 +31,14 @@ describe('what the scrub bar spans', () => {
   it('spans the whole clip when looping is off', () => {
     expect(
       spanned({ loop: aLoop({ a: 3, b: 9 }), looping: false, duration: 12 }),
-    ).toEqual({ from: 0, to: 12 })
+    ).toEqual({ from: 0, to: 12, rescaled: false })
   })
 
   it('spans the whole clip when the loop already is the whole clip', () => {
     expect(spanned({ loop: aLoop(), looping: true, duration: 12 })).toEqual({
       from: 0,
       to: 12,
+      rescaled: false,
     })
   })
 
@@ -48,13 +49,13 @@ describe('what the scrub bar spans', () => {
   it('counts a B a rounding error short of the end as the end', () => {
     expect(
       spanned({ loop: aLoop({ b: 12 - EDGE / 2 }), looping: true, duration: 12 }),
-    ).toEqual({ from: 0, to: 12 })
+    ).toEqual({ from: 0, to: 12, rescaled: false })
   })
 
   it('counts an A a rounding error past the start as the start', () => {
     expect(
       spanned({ loop: aLoop({ a: EDGE / 2 }), looping: true, duration: 12 }),
-    ).toEqual({ from: 0, to: 12 })
+    ).toEqual({ from: 0, to: 12, rescaled: false })
   })
 
   /* One end being meaningfully inside is enough to be penned in, so a loop that
@@ -64,7 +65,7 @@ describe('what the scrub bar spans', () => {
   it('spans a loop that reaches the end but starts well inside', () => {
     expect(
       spanned({ loop: aLoop({ a: 5, b: 12 }), looping: true, duration: 12 }),
-    ).toEqual({ from: 5, to: 12 })
+    ).toEqual({ from: 5, to: 12, rescaled: true })
   })
 
   /* Before metadata there is no clip to span. Answering 0..0 rather than
@@ -73,6 +74,7 @@ describe('what the scrub bar spans', () => {
     expect(spanned({ loop: aLoop(), looping: true, duration: 0 })).toEqual({
       from: 0,
       to: 0,
+      rescaled: false,
     })
   })
 
@@ -82,7 +84,7 @@ describe('what the scrub bar spans', () => {
   it('spans the whole clip rather than an inverted loop', () => {
     expect(
       spanned({ loop: aLoop({ a: 9, b: 3 }), looping: true, duration: 12 }),
-    ).toEqual({ from: 0, to: 12 })
+    ).toEqual({ from: 0, to: 12, rescaled: false })
   })
 })
 

--- a/app/src/player/scrubSpan.ts
+++ b/app/src/player/scrubSpan.ts
@@ -1,3 +1,4 @@
+import { clamp, type Track } from './loopRange'
 import type { Loop } from './playback'
 
 /* How close to an end of the clip still counts as being at it. A and B arrive
@@ -47,4 +48,42 @@ export const spanned = ({
     (loop.a > EDGE || loop.b < duration - EDGE)
 
   return penned ? { from: loop.a, to: loop.b } : { from: 0, to: duration }
+}
+
+/* Where a moment sits along the bar, as a fraction of the span rather than of
+   the clip — which is what draws the playhead in the right place once the bar
+   has rescaled: empty at A, full at B, whatever the clip's length.
+
+   Clamped because the playhead can be outside the span for a moment: the loop
+   was just moved, or looping was turned on while the clip was elsewhere. It
+   parks at the end it went past rather than being drawn off the bar. */
+export const ratioOf = (seconds: number, span: Span) => {
+  const width = span.to - span.from
+
+  if (width <= 0) return 0
+
+  return clamp((seconds - span.from) / width, 0, 1)
+}
+
+/* The same relationship read the other way: a pointer on the bar is a moment in
+   the span. Kept beside `ratioOf` because they are one mapping, and separating
+   them is how the drawn position and the dragged one come to disagree.
+
+   This is where criterion four is enforced, and it is enforced by not existing:
+   a ratio cannot leave 0..1, so the span's ends are the only places a drag can
+   reach. Nothing has to refuse the part of the drag that goes past them. */
+export const secondsAt = ({
+  clientX,
+  track,
+  span,
+}: {
+  readonly clientX: number
+  readonly track: Track
+  readonly span: Span
+}) => {
+  if (track.width <= 0) return span.from
+
+  const ratio = clamp((clientX - track.left) / track.width, 0, 1)
+
+  return span.from + ratio * (span.to - span.from)
 }

--- a/app/src/player/scrubSpan.ts
+++ b/app/src/player/scrubSpan.ts
@@ -1,0 +1,50 @@
+import type { Loop } from './playback'
+
+/* How close to an end of the clip still counts as being at it. A and B arrive
+   from a drag across real geometry, so a loop the dancer dragged out to the very
+   end lands a rounding error short of `duration` about half the time — and an
+   exact comparison would leave the bar zoomed to 99.9% of the clip, which reads
+   as a bug and scrubs like one. */
+export const EDGE = 0.05
+
+/* What the bar lays itself out against. Named rather than a bare pair because
+   every reading below is relative to it: a ratio is a position within the span,
+   never within the clip. */
+export type Span = {
+  readonly from: number
+  readonly to: number
+}
+
+/* The rescale, and the whole reason this is not a second loop slider. Six
+   seconds of a 2:28 clip is 4% of the bar — technically scrubbable, actually
+   impossible, and the tighter the loop the worse it gets, which is backwards: a
+   tight loop is exactly when you most need to move inside it.
+
+   So the bar spans the loop whenever there is a loop penning the playhead in.
+   The full width always buys you the loop, so a narrower loop scrubs finer.
+
+   It also replaces clamping rather than adding to it. Nothing has to refuse a
+   drag or dim what is out of reach — outside the loop is simply off the end of
+   the bar, and a ratio cannot leave 0..1.
+
+   A loop spanning the whole clip pens nothing in, so it does not rescale: that
+   is the case that leaves the rest of the clip reachable at all. One end being
+   meaningfully inside is enough, because a loop trimmed only at the front is the
+   commonest kind and wants the rescale as much as any other. */
+export const spanned = ({
+  loop,
+  looping,
+  duration,
+}: {
+  readonly loop: Loop
+  readonly looping: boolean
+  readonly duration: number
+}): Span => {
+  const penned =
+    looping &&
+    duration > 0 &&
+    loop.b > loop.a &&
+    (loop.a > EDGE || loop.b < duration - EDGE)
+
+  return penned ? { from: loop.a, to: loop.b } : { from: 0, to: duration }
+}

--- a/app/src/player/scrubSpan.ts
+++ b/app/src/player/scrubSpan.ts
@@ -1,4 +1,4 @@
-import { clamp, type Track } from './loopRange'
+import { clamp, ratioAt, type Track } from './loopRange'
 import type { Loop } from './playback'
 
 /* How close to an end of the clip still counts as being at it. A and B arrive
@@ -82,10 +82,4 @@ export const secondsAt = ({
   readonly clientX: number
   readonly track: Track
   readonly span: Span
-}) => {
-  if (track.width <= 0) return span.from
-
-  const ratio = clamp((clientX - track.left) / track.width, 0, 1)
-
-  return span.from + ratio * (span.to - span.from)
-}
+}) => span.from + ratioAt({ clientX, track }) * (span.to - span.from)

--- a/app/src/player/scrubSpan.ts
+++ b/app/src/player/scrubSpan.ts
@@ -40,14 +40,16 @@ export const spanned = ({
   readonly loop: Loop
   readonly looping: boolean
   readonly duration: number
-}): Span => {
+}): Span & { readonly rescaled: boolean } => {
   const penned =
     looping &&
     duration > 0 &&
     loop.b > loop.a &&
     (loop.a > EDGE || loop.b < duration - EDGE)
 
-  return penned ? { from: loop.a, to: loop.b } : { from: 0, to: duration }
+  return penned
+    ? { from: loop.a, to: loop.b, rescaled: true }
+    : { from: 0, to: duration, rescaled: false }
 }
 
 /* Where a moment sits along the bar, as a fraction of the span rather than of

--- a/mockup/src/Player.jsx
+++ b/mockup/src/Player.jsx
@@ -283,6 +283,115 @@ function BigButton({ label, active, onClick, children }) {
   )
 }
 
+/* Where you are in the clip, drawn on the clip itself, and how you go somewhere
+   else. Deliberately the same shape as the loop slider below it, because the two
+   answer different questions about the same timeline: this one is "where am I",
+   that one is "which few seconds am I working on". Neither can do the other's job.
+
+   Rides inside the video wrapper rather than under the card, so it survives zen
+   mode — which is where it matters most, since the whole control strip is hidden
+   there and the clip is otherwise playing completely blind.
+
+   The container stays `pointer-events-none` and only the grab strip takes them
+   back: the video surface is the play/pause target, so a bar that swallowed the
+   whole bottom of the frame would cost you tapping the clip to pause it. */
+function VideoProgress({ time, duration, loop, looping, onScrub, rounded }) {
+  const track = useRef(null)
+  const [dragging, setDragging] = useState(false)
+
+  /* Whether the loop pens the playhead in. A loop spanning the whole clip
+     constrains nothing, so scrubbing is free — which is the case that matters,
+     because it is how you get to look at the rest of the clip at all.
+
+     The epsilon is not fussiness: A and B arrive from a drag across real
+     geometry, so "the whole clip" is 0.0000001 short of it about half the time. */
+  const penned =
+    looping && duration > 0 && loop.b > loop.a && (loop.a > 0.05 || loop.b < duration - 0.05)
+
+  /* The bar spans the loop, not the clip, whenever there is a loop to span. Six
+     seconds of a 2:28 clip is 4% of the width — technically scrubbable, actually
+     impossible, and the narrower the loop the worse it gets, which is backwards:
+     a tight loop is exactly when you most need to move within it.
+
+     Rescaling turns that around. The full width always buys you the loop, so the
+     tighter the loop the finer the scrub — 40x here, and it costs nothing to
+     reach because it is the width you were already dragging across.
+
+     It also subsumes the clamping this used to do. Nothing has to refuse a drag
+     or dim what is out of reach: outside the loop is simply off the end of the
+     bar, and a ratio cannot leave 0..1. */
+  const domain = penned ? { from: loop.a, to: loop.b } : { from: 0, to: duration }
+  const span = domain.to - domain.from
+
+  const pct = (seconds) =>
+    span > 0 ? Math.min(Math.max(((seconds - domain.from) / span) * 100, 0), 100) : 0
+
+  const timeAt = (clientX) => {
+    const rect = track.current?.getBoundingClientRect()
+    if (!rect || rect.width === 0) return domain.from
+
+    const ratio = Math.min(Math.max((clientX - rect.left) / rect.width, 0), 1)
+
+    return domain.from + ratio * span
+  }
+
+  return (
+    <div
+      className={`pointer-events-none absolute inset-x-0 bottom-0 select-none bg-gradient-to-t from-black/70 to-transparent px-2 pb-2 pt-8 ${rounded}`}
+    >
+      {/* Two facts, and the row has room for both. Left: what the bar spans, shown
+          only when that is no longer the whole clip — without it a playhead
+          sitting mid-bar at 01:03 of a 02:28 clip is simply wrong-looking, and
+          the rescale is invisible. Right: where you actually are, unchanged and
+          always absolute, because that is the number you came for. */}
+      <div className="mb-1.5 flex items-baseline justify-between gap-2">
+        <span className="text-[11px] tabular-nums text-white/60 drop-shadow">
+          {penned ? `${formatTime(domain.from)} – ${formatTime(domain.to)}` : ''}
+        </span>
+        <span className="text-[11px] tabular-nums text-white/80 drop-shadow">
+          {formatTime(time)} / {formatTime(duration)}
+        </span>
+      </div>
+
+      {/* A 2px line is not a touch target. The padding gives the thumb ~28px to
+          land in while the line stays hairline-thin, and `touch-none` stops the
+          drag being read as a page scroll on a phone. */}
+      <div
+        ref={track}
+        className="group pointer-events-auto -my-3 cursor-pointer touch-none py-3"
+        onPointerDown={(event) => {
+          event.currentTarget.setPointerCapture?.(event.pointerId)
+          setDragging(true)
+          onScrub(timeAt(event.clientX))
+        }}
+        onPointerMove={(event) => dragging && onScrub(timeAt(event.clientX))}
+        onPointerUp={(event) => {
+          event.currentTarget.releasePointerCapture?.(event.pointerId)
+          setDragging(false)
+        }}
+        onPointerCancel={() => setDragging(false)}
+      >
+        <div
+          className={`relative w-full rounded-full bg-white/20 transition-[height] ${
+            dragging ? 'h-1' : 'h-0.5 group-hover:h-1'
+          }`}
+        >
+          <div
+            className="absolute inset-y-0 left-0 rounded-full bg-white"
+            style={{ width: `${pct(time)}%` }}
+          />
+          <div
+            className={`absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow transition-transform ${
+              dragging ? 'scale-100' : 'scale-0 group-hover:scale-100'
+            }`}
+            style={{ left: `${pct(time)}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function Player({ clip, onBack }) {
   const videoRef = useRef(null)
   const [duration, setDuration] = useState(0)
@@ -507,6 +616,17 @@ function Player({ clip, onBack }) {
               onPlay={() => setPlaying(true)}
               onPause={() => setPlaying(false)}
               onClick={togglePlay}
+            />
+
+            <VideoProgress
+              time={time}
+              duration={duration}
+              loop={loop}
+              looping={looping}
+              onScrub={scrub}
+              /* Follows the clip's own corners so the scrim doesn't square off a
+                 rounded video. Zen has no rounding to follow. */
+              rounded={zen ? undefined : 'rounded-b-lg'}
             />
 
             <button


### PR DESCRIPTION
**Ticket:** #21

## Summary

- A position bar on the clip itself — elapsed/total time and a fill — mounted **inside the video wrapper**, so it survives zen structurally rather than through a second code path. Zen hides the whole control strip, which is exactly where knowing your position matters most.
- **The bar spans the loop, not the clip**, whenever a loop pens the playhead in. Six seconds of a 2:28 clip is 4% of the loop slider's track; here the full width always buys you the loop, so a *tighter* loop scrubs *finer* — the opposite of the slider, and ~40x in the case that prompted the ticket.
- The rescale replaces clamping rather than adding to it. Nothing refuses a drag or dims what is out of reach: outside the loop is off the end of the bar, and a ratio cannot leave 0..1.
- A range label (`0:02 – 0:06`) carries the rescale, which is otherwise abrupt and invisible. No animated transition — the playhead did not move, and animating would say it did.
- Geometry lives in a pure module (`scrubSpan.ts`), because jsdom lays nothing out — the same reason `loopRange.ts` exists beside the loop slider.

## The decision the mockup left open

Dragging to the far end lands exactly on B, and enforcement fires on `currentTime >= b` — so the playhead jumped to A while the finger was still at the right-hand edge.

**Settled by standing enforcement down for the length of the drag**, via the `onHold` → `setAdjusting` route BR-19 already built for handle drags. Its reasoning transfers whole: the clip genuinely is at B, it was put there on purpose, and no reading of `currentTime` tells that apart from having arrived. The alternative reading — "it is a loop, so wrapping is correct" — makes the ticket's own fourth criterion false.

On release or cancel the loop is taken back up, so landing on B and letting go wraps to A on the next frame.

## Not verified — please read

Three criteria have **no test behind them**: grabbable with a thumb, the drag not scrolling the page, and tap-to-pause still working. jsdom implements neither `pointer-events` nor `touch-action`, so all that could be asserted is that the classes are present. That is written as a single test rather than three, deliberately, so a green suite does not imply coverage it does not have.

The hands-on smoke test was **skipped at Thomas's request**, on the strength of the mockup pass.

## Test plan

- [x] `node scripts/verify.mjs` → `GATE: PASS`, 7 checks green, 5 skipped
- [x] 273 tests green in `app`
- [x] The rescale pinned as a pair: the same playhead reads 50% against a 2s loop and 25% once released
- [x] "Travels exactly the loop and no further" — drag past the end lands on B
- [x] Scrubbing never moves A or B
- [ ] **Phone:** thumb target, drag does not scroll, tap-to-pause — unverified

## TDD evidence

RED→GREEN→REFACTOR, one commit per plan step, gate green at each:

| | |
|---|---|
| `393ce72` | the mockup, as the reference |
| `5e91a4b` | what the bar spans — the rescale rule + epsilon |
| `5a2504b` | the mapping both ways |
| `31ec0ee` | draw the bar on the clip |
| `2411751` | span the loop, and say so |
| `76c0adb` | scrub by dragging |
| `fa6a39c` | stand the loop down during the drag |
| `5cd550d` | the thumb/touch guards |
| `bcdb7aa` | refactor: read a pointer along a bar in one place |

## Knock-on for #19

This narrows it, as the ticket predicted. #19 currently claims the bar's existence and the mockup pass as its own criteria, both delivered here. Left untouched deliberately — #21 says to re-read it once the rescale has been used for real, not to close it blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gZfpvFyvGK93DkmjYVuBS