### PR TITLE
#23 the scrub bar keeps up with the finger

### DIFF
--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -2621,6 +2621,21 @@ describe('scrubbing faster than the seeks can land', () => {
      it started, or a nudge against the end of the clip, would leave the gate
      waiting for a report that is never coming. Without a way back out, the bar
      would simply stop moving for the rest of the session. */
+  /* Where the drag ended is the one position that must survive being dropped —
+     it is where the dancer chose to leave the clip. It survives because it is
+     never superseded: the gate holds the newest ask, and after the finger lifts
+     there is no newer one for it to be replaced by. */
+  it('settles where the finger left it, not where the last issued seek was', () => {
+    const clip = aReadyClip({ seconds: 12 })
+    const land = holdSeeks(clip)
+
+    dragAcross(50, 100, 150)
+    fireEvent.pointerUp(aLaidOutBar(), { pointerId: 1 })
+    land()
+
+    expect(clip.currentTime).toBe(9)
+  })
+
   it('reopens the gate when a seek never reports back', () => {
     vi.useFakeTimers()
     const clip = aReadyClip({ seconds: 12 })

--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -26,6 +26,7 @@ import { NO_LOOPS } from '../loops/loopsFile'
 import { inDocumentOrder } from '../test/documentOrder'
 import { laidOut } from '../test/layout'
 import { holdSeeks, playable, runsOut, seeksSeen } from '../test/media'
+import { SEEK_BACKSTOP } from './seekGate'
 import { PlayerScreen } from './PlayerScreen'
 
 /* The player reaches Drive now, for a clip this device has never held
@@ -2613,6 +2614,22 @@ describe('scrubbing faster than the seeks can land', () => {
     land()
 
     expect(seeksSeen(clip)).toEqual([3, 9])
+  })
+
+  /* Not a hypothetical lost event. Assigning `currentTime` the value the element
+     already holds fires no `seeked` at all — so a drag that comes back to where
+     it started, or a nudge against the end of the clip, would leave the gate
+     waiting for a report that is never coming. Without a way back out, the bar
+     would simply stop moving for the rest of the session. */
+  it('reopens the gate when a seek never reports back', () => {
+    vi.useFakeTimers()
+    const clip = aReadyClip({ seconds: 12 })
+    holdSeeks(clip)
+
+    dragAcross(50, 150)
+    act(() => vi.advanceTimersByTime(SEEK_BACKSTOP))
+
+    expect(clip.currentTime).toBe(9)
   })
 })
 

--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -25,7 +25,7 @@ import { A_REFUSAL, useFakeLoops } from '../loops/loopsHandle.factory'
 import { NO_LOOPS } from '../loops/loopsFile'
 import { inDocumentOrder } from '../test/documentOrder'
 import { laidOut } from '../test/layout'
-import { playable, runsOut } from '../test/media'
+import { holdSeeks, playable, runsOut, seeksSeen } from '../test/media'
 import { PlayerScreen } from './PlayerScreen'
 
 /* The player reaches Drive now, for a clip this device has never held
@@ -2562,6 +2562,57 @@ describe('scrubbing the position bar', () => {
     scrubAt(50)
 
     expect(scrubFill()).toHaveStyle({ width: '25%' })
+  })
+})
+
+/* The half of #19 that turned out to matter. A pointermove fires far faster than
+   a seek on a ~6MB clip can land — the mockup gate measured a median of 49 ms
+   against a pointer stream arriving every few milliseconds — so seeking on every
+   one of them builds a queue the decoder works through late, and the clip chases
+   where the finger was half a second ago.
+
+   Dropping the intermediate positions rather than queueing them is what keeps the
+   clip under the thumb. It is not a compromise on precision: a slow drag, where
+   seeks land faster than the finger asks, still resolves every frame. */
+describe('scrubbing faster than the seeks can land', () => {
+  const dragAcross = (...positions: readonly number[]) => {
+    fireEvent.pointerDown(aLaidOutBar(), { pointerId: 1, clientX: positions[0] })
+
+    for (const clientX of positions.slice(1))
+      fireEvent.pointerMove(aLaidOutBar(), { pointerId: 1, clientX })
+  }
+
+  it('holds a position back while the last seek is still in flight', () => {
+    const clip = aReadyClip({ seconds: 12 })
+    holdSeeks(clip)
+
+    dragAcross(50, 150)
+
+    expect(clip.currentTime).toBe(3)
+  })
+
+  it('seeks to the newest position once the one in flight lands', () => {
+    const clip = aReadyClip({ seconds: 12 })
+    const land = holdSeeks(clip)
+
+    dragAcross(50, 150)
+    land()
+
+    expect(clip.currentTime).toBe(9)
+  })
+
+  /* The line between this and a queue, and the only assertion that can draw it —
+     a queue and a gate agree about where the drag ended and disagree about
+     everything on the way. 100 and 120 are where the finger was and had left
+     before either could be issued. */
+  it('never seeks to the positions it passed over', () => {
+    const clip = aReadyClip({ seconds: 12 })
+    const land = holdSeeks(clip)
+
+    dragAcross(50, 100, 120, 150)
+    land()
+
+    expect(seeksSeen(clip)).toEqual([3, 9])
   })
 })
 

--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -2646,6 +2646,47 @@ describe('scrubbing faster than the seeks can land', () => {
 
     expect(clip.currentTime).toBe(9)
   })
+
+  /* The other half of keeping up, and the one that is visible rather than
+     measurable. Dropping the queue stops the clip falling behind; this stops the
+     *bar* falling behind, which is what the thumb is actually watching.
+
+     BR-07 samples `currentTime` every frame, so a seek still in flight would have
+     the marker snap back to wherever the decoder had got to — the finger at 75%
+     and the fill at 25% under it, a frame after the drag put it there. That
+     rubber-band is what reads as the bar fighting the thumb.
+
+     Enforcement already stands down for a held boundary under BR-19. This is the
+     same clip pulled two ways by the same hand, so the marker stands down with
+     it. */
+  describe('while the seek catches up', () => {
+    it('draws where the finger is, not where the decoder is', () => {
+      vi.useFakeTimers()
+      const clip = aReadyClip({ seconds: 12 })
+      holdSeeks(clip)
+      fireEvent.play(clip)
+
+      dragAcross(50, 150)
+      act(() => vi.advanceTimersByTime(A_FEW_FRAMES))
+
+      expect(scrubFill()).toHaveStyle({ width: '75%' })
+    })
+
+    /* The half that stops this becoming a marker that freezes. Standing down is
+       for the length of the hold and no longer. */
+    it('goes back to tracking the clip once the drag is released', () => {
+      vi.useFakeTimers()
+      const clip = aReadyClip({ seconds: 12 })
+      fireEvent.play(clip)
+
+      dragAcross(150)
+      fireEvent.pointerUp(aLaidOutBar(), { pointerId: 1 })
+      clip.currentTime = 6
+      act(() => vi.advanceTimersByTime(A_FEW_FRAMES))
+
+      expect(scrubFill()).toHaveStyle({ width: '50%' })
+    })
+  })
 })
 
 /* BR-19 again, and the one piece of behaviour the mockup left for the app to

--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -385,6 +385,19 @@ describe('the player', () => {
     expect(clipSurface(container)).toHaveAttribute('src', '/wave-practice.mp4')
   })
 
+  /* The default fetches metadata and stops, so scrubbing past whatever happened
+     to arrive turns every seek into a network fetch *and* a decode — which is
+     most of what read as the clip freezing under the thumb. Chrome had 4.9s of a
+     26.7s clip in hand when the mockup gate measured it, on localhost.
+
+     Clips are ~6MB and the app is cache-first anyway, so there is no version of
+     this where fetching the rest later is the better trade. */
+  it('fetches the whole clip rather than only its metadata', () => {
+    const { container } = renderPlayer(getClip({ src: '/wave-practice.mp4' }))
+
+    expect(clipSurface(container)).toHaveAttribute('preload', 'auto')
+  })
+
   it('reserves the controls their places, in the order they will be used', () => {
     const { container } = renderPlayer(getClip({ src: '/shuffle-drill.mp4' }))
 

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -762,6 +762,15 @@ function OpenedClip({
                     : 'mx-auto block max-h-[50vh] max-w-full rounded-lg bg-black lg:max-h-[80vh]'
                 }
                 playsInline
+                /* The default fetches metadata and stops, so scrubbing past
+                   whatever happened to arrive turns every seek into a network
+                   fetch *and* a decode — most of what read as the clip freezing
+                   under the thumb. The mockup gate found Chrome holding 4.9s of a
+                   26.7s clip, on localhost.
+
+                   Clips are ~6MB and the app is cache-first regardless, so there
+                   is no version of this where fetching the rest later wins. */
+                preload="auto"
                 onLoadedMetadata={(event) =>
                   setPlayback(decoded(event.currentTarget.duration))
                 }

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -32,6 +32,7 @@ import {
   StartGlyph,
   TransportButton,
 } from './TransportButton'
+import { type Gate, idle, type Move, requested, settled } from './seekGate'
 import { VideoProgress } from './VideoProgress'
 
 /* Asked of the element every time, rather than of a flag the screen keeps.
@@ -299,13 +300,46 @@ function OpenedClip({
   const saved = loopsFor(loops.loops, clip.id)
   const [loopName, setLoopName] = useState('')
 
+  /* One seek in flight at a time, and the rest of the drag dropped rather than
+     queued — #23. A ref rather than state because every read and write happens
+     inside the same pointermove, and re-rendering per move would put a frame
+     between the finger and the seek it asked for. */
+  const gate = useRef<Gate>(idle)
+
+  /* Whatever the finger last asked for, kept because the gate may well have
+     dropped it: releasing has to settle on where the drag ended, not on the last
+     position that happened to be issued. */
+  const wanted = useRef(0)
+
+  const issue = (move: Move) => {
+    gate.current = move.gate
+
+    /* Exact, never `fastSeek`. That was tried at the mockup gate and removed: it
+       snaps to the nearest keyframe, seconds away on this footage, so it *is* the
+       freeze-and-jump it looks like a cure for and it takes the frame-by-frame
+       resolution with it. */
+    if (move.seek !== null && surface.current)
+      surface.current.currentTime = move.seek
+  }
+
   /* Writes both, because a scrub while paused moves the playhead and no frame is
      scheduled to notice: the marker would sit where the clip used to be until
-     something else started it. */
+     something else started it.
+
+     `setTime` takes the position asked for rather than the one issued, so the
+     drawn playhead follows the finger even while the seek that will catch up to
+     it is still in flight. */
   const seekTo = (seconds: number) => {
-    if (surface.current) surface.current.currentTime = seconds
+    wanted.current = seconds
+    issue(requested(gate.current, seconds))
     setTime(seconds)
   }
+
+  /* The element saying the seek arrived, which is the only thing that can. Loop
+     enforcement writes `currentTime` straight onto the element without asking the
+     gate — a correctness rule, not a drag — and the `seeked` it fires lands here
+     too, where settling an idle gate is a no-op. */
+  const seekLanded = () => issue(settled(gate.current))
 
   /* Written straight onto the element, because `playbackRate` is a property
      rather than an attribute React could render. Nothing here plays, pauses or
@@ -693,6 +727,7 @@ function OpenedClip({
                   setPlayback(decoded(event.currentTarget.duration))
                 }
                 onError={() => setPlayback(undecodable)}
+                onSeeked={seekLanded}
                 onClick={(event) => togglePlay(event.currentTarget)}
                 onPlay={() => setPlaying(true)}
                 onPause={() => setPlaying(false)}

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -32,7 +32,14 @@ import {
   StartGlyph,
   TransportButton,
 } from './TransportButton'
-import { type Gate, idle, type Move, requested, settled } from './seekGate'
+import {
+  type Gate,
+  idle,
+  type Move,
+  requested,
+  SEEK_BACKSTOP,
+  settled,
+} from './seekGate'
 import { VideoProgress } from './VideoProgress'
 
 /* Asked of the element every time, rather than of a flag the screen keeps.
@@ -311,15 +318,42 @@ function OpenedClip({
      position that happened to be issued. */
   const wanted = useRef(0)
 
+  /* The way back out of a seek that never reports. Armed with the seek and
+     cleared by whatever settles it, so at most one is ever outstanding. */
+  const backstop = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const disarm = () => {
+    if (backstop.current !== null) clearTimeout(backstop.current)
+    backstop.current = null
+  }
+
   const issue = (move: Move) => {
     gate.current = move.gate
+
+    /* Nothing going out. The backstop stands down only when there is no longer a
+       seek for it to cover — a request that was *held back* leaves the one before
+       it still in flight, and clearing the timer then would take away the only
+       way back out of a seek that never reports. */
+    if (move.seek === null) {
+      if (!move.gate.inFlight) disarm()
+      return
+    }
+
+    disarm()
+
+    /* Armed before the write, not after: the element can report back inside the
+       assignment itself, and a backstop armed afterwards would outlive the seek
+       it was covering. */
+    backstop.current = setTimeout(
+      () => issue(settled(gate.current)),
+      SEEK_BACKSTOP,
+    )
 
     /* Exact, never `fastSeek`. That was tried at the mockup gate and removed: it
        snaps to the nearest keyframe, seconds away on this footage, so it *is* the
        freeze-and-jump it looks like a cure for and it takes the frame-by-frame
        resolution with it. */
-    if (move.seek !== null && surface.current)
-      surface.current.currentTime = move.seek
+    if (surface.current) surface.current.currentTime = move.seek
   }
 
   /* Writes both, because a scrub while paused moves the playhead and no frame is

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -313,11 +313,6 @@ function OpenedClip({
      between the finger and the seek it asked for. */
   const gate = useRef<Gate>(idle)
 
-  /* Whatever the finger last asked for, kept because the gate may well have
-     dropped it: releasing has to settle on where the drag ended, not on the last
-     position that happened to be issued. */
-  const wanted = useRef(0)
-
   /* The way back out of a seek that never reports. Armed with the seek and
      cleared by whatever settles it, so at most one is ever outstanding. */
   const backstop = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -364,7 +359,6 @@ function OpenedClip({
      drawn playhead follows the finger even while the seek that will catch up to
      it is still in flight. */
   const seekTo = (seconds: number) => {
-    wanted.current = seconds
     issue(requested(gate.current, seconds))
     setTime(seconds)
   }

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -386,9 +386,20 @@ function OpenedClip({
      got to. Gated on playing alone, so a paused clip still schedules nothing.
 
      The rate is not a dependency here either: a slowed clip reports a slower
-     `currentTime` and the marker follows it, so there is nothing to recompute. */
+     `currentTime` and the marker follows it, so there is nothing to recompute.
+
+     `adjusting` stands it down for #23, the way it already stands enforcement
+     down under BR-19 — and for the same reason, one step further along. A seek
+     takes ~50 ms to land and a pointermove arrives every few, so through a drag
+     the element's `currentTime` is wherever the decoder has got to rather than
+     where the finger is. Sampling it then snaps the marker back behind the thumb
+     a frame after the drag put it there — the finger at 75% and the fill at 25%
+     underneath it, which is the rubber-band that read as the bar fighting the
+     hand. While the drag holds, `seekTo`'s own optimistic `setTime` is the only
+     thing that moves the marker, so it tracks the finger and the clip catches
+     up. */
   useEffect(() => {
-    if (playback.kind !== 'ready' || !playing) return
+    if (playback.kind !== 'ready' || !playing || adjusting) return
 
     let frame = 0
     const tick = () => {
@@ -400,7 +411,7 @@ function OpenedClip({
     frame = requestAnimationFrame(tick)
 
     return () => cancelAnimationFrame(frame)
-  }, [playback.kind, playing])
+  }, [playback.kind, playing, adjusting])
 
   /* BR-07: per animation frame, not on the video's own progress events. Those
      fire at about 4 Hz, and the spike measured 86 ms of overshoot on a two-second

--- a/app/src/player/seekGate.test.ts
+++ b/app/src/player/seekGate.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { type Gate, idle, requested, settled } from './seekGate'
+
+const inFlight = ({ pending = null }: Partial<Gate> = {}): Gate => ({
+  inFlight: true,
+  pending,
+})
+
+/* A pointermove fires far faster than a seek on a ~6MB clip can land — the mockup
+   gate measured a median of 49 ms for a small drag against a pointer stream
+   arriving every few milliseconds. Assigning `currentTime` on every one of them
+   builds a queue the decoder then works through late, and the clip ends up
+   chasing where the finger was half a second ago.
+
+   The fix is not to go faster. It is to notice that every target but the newest
+   is already wrong by the time it could be issued, and to forget them rather than
+   promise them. */
+describe('asking the gate for a seek', () => {
+  it('issues it straight away when nothing is in flight', () => {
+    expect(requested(idle, 5)).toEqual({
+      gate: { inFlight: true, pending: null },
+      seek: 5,
+    })
+  })
+
+  it('holds it back while a seek is still in flight', () => {
+    expect(requested(inFlight(), 7)).toEqual({
+      gate: { inFlight: true, pending: 7 },
+      seek: null,
+    })
+  })
+
+  /* The whole point, and the line between this and a queue. A second ask does not
+     get in line behind the first — it replaces it, because the first is already
+     somewhere the finger has left. */
+  it('replaces a held target rather than queueing behind it', () => {
+    expect(requested(inFlight({ pending: 7 }), 9)).toEqual({
+      gate: { inFlight: true, pending: 9 },
+      seek: null,
+    })
+  })
+})
+
+describe('a seek landing', () => {
+  it('issues the newest target that was held back', () => {
+    expect(settled(inFlight({ pending: 9 }))).toEqual({
+      gate: { inFlight: true, pending: null },
+      seek: 9,
+    })
+  })
+
+  it('goes idle when nothing was held back', () => {
+    expect(settled(inFlight())).toEqual({ gate: idle, seek: null })
+  })
+
+  /* Loop enforcement writes `currentTime` straight onto the element — it is a
+     correctness rule rather than a drag, and it does not ask the gate. The
+     `seeked` it fires still arrives here, so a settle against an idle gate has to
+     be a no-op rather than something that leaves it wedged open. */
+  it('is a no-op when no seek was in flight at all', () => {
+    expect(settled(idle)).toEqual({ gate: idle, seek: null })
+  })
+})

--- a/app/src/player/seekGate.ts
+++ b/app/src/player/seekGate.ts
@@ -1,0 +1,49 @@
+/* One seek in flight, always to the newest place the finger has asked for.
+
+   A `pointermove` fires far faster than a seek on a ~6MB clip can land — the
+   mockup gate measured a median of 49 ms against a pointer stream arriving every
+   few milliseconds — so assigning `currentTime` on every one of them builds a
+   queue the decoder then works through late, and the clip chases where the finger
+   was half a second ago. That lag is what read as the bar freezing and jumping,
+   and it is what #19 spent its whole life mistaking for a gain curve.
+
+   The fix is not to seek faster. It is that every target but the newest is
+   already wrong by the time it could be issued, so the gate forgets them instead
+   of promising them. A fast drag therefore shows fewer frames but never falls
+   behind, and a slow one — where seeks land faster than the finger asks — still
+   resolves every single frame, which is the case this exists for.
+
+   Pure, and separated from the element for `scrubSpan`'s reason: the arithmetic
+   of what to seek and when is the part worth testing, and jsdom has no decoder to
+   test it against. */
+export type Gate = {
+  readonly inFlight: boolean
+  /* The one target held back, or nothing. Never a list — a queue is the bug. */
+  readonly pending: number | null
+}
+
+export const idle: Gate = { inFlight: false, pending: null }
+
+/* Both readings return the gate's next state and the seek to issue, if any, so
+   the caller never has to work out which it is. `null` means issue nothing. */
+export type Move = {
+  readonly gate: Gate
+  readonly seek: number | null
+}
+
+export const requested = (gate: Gate, seconds: number): Move =>
+  gate.inFlight
+    ? { gate: { inFlight: true, pending: seconds }, seek: null }
+    : { gate: { inFlight: true, pending: null }, seek: seconds }
+
+/* A settle against an idle gate is a no-op rather than an error. Loop enforcement
+   writes `currentTime` straight onto the element — a correctness rule, not a
+   drag, and it does not ask the gate — but the `seeked` it fires still arrives
+   here. */
+export const settled = (gate: Gate): Move => {
+  if (!gate.inFlight) return { gate: idle, seek: null }
+
+  if (gate.pending === null) return { gate: idle, seek: null }
+
+  return { gate: { inFlight: true, pending: null }, seek: gate.pending }
+}

--- a/app/src/player/seekGate.ts
+++ b/app/src/player/seekGate.ts
@@ -24,6 +24,21 @@ export type Gate = {
 
 export const idle: Gate = { inFlight: false, pending: null }
 
+/* How long to wait for a seek to report back before assuming it never will.
+
+   This is not a guard against a hypothetically lost event. Assigning
+   `currentTime` the value the element already holds fires no `seeked` at all —
+   so a drag that comes back to where it started, or a nudge against the end of
+   the clip, would leave the gate waiting for a report that is never coming and
+   the bar would stop moving for the rest of the session.
+
+   Well above the 88 ms worst case the mockup gate measured, because the cost of
+   being wrong in each direction is not symmetric: too long only delays the
+   recovery from a seek that was never going to land, while too short would issue
+   a second seek over a first that was merely slow, which is the queue this whole
+   thing exists to avoid. */
+export const SEEK_BACKSTOP = 400
+
 /* Both readings return the gate's next state and the seek to issue, if any, so
    the caller never has to work out which it is. `null` means issue nothing. */
 export type Move = {

--- a/app/src/test/media.ts
+++ b/app/src/test/media.ts
@@ -14,12 +14,34 @@
    can stop playback the way the outside world does, by firing pause. It is the
    one piece of mutable state here, and it is mutable because the thing being
    stood in for is. */
+/* What a test needs to reach about a clip's seeking that the element itself does
+   not expose: whether its seeks are landing yet, and every position written to it
+   so far. Held beside the element rather than on it, so the double keeps a real
+   element's public shape and nothing under test can read it by accident. */
+type Seeking = {
+  held: boolean
+  readonly writes: number[]
+}
+
+const seeking = new WeakMap<HTMLVideoElement, Seeking>()
+
+const controlFor = (video: HTMLVideoElement) => {
+  const control = seeking.get(video)
+
+  if (!control) throw new Error('That clip surface was never made playable')
+
+  return control
+}
+
 export const playable = (
   video: HTMLVideoElement,
   { seconds }: { readonly seconds: number },
 ) => {
   let paused = true
   let currentTime = 0
+  const control: Seeking = { held: false, writes: [] }
+
+  seeking.set(video, control)
 
   Object.defineProperty(video, 'duration', {
     value: seconds,
@@ -28,13 +50,23 @@ export const playable = (
 
   /* jsdom implements no seeking either: `currentTime` reads 0 forever and writing
      it does nothing, so a test could neither move the playhead nor watch anything
-     move it back. A real element would fire `seeked` and `timeupdate` off this;
-     nothing reads those, so it stays a plain readable-writable position — which is
-     all the loop and START need it to be. */
+     move it back.
+
+     It fires `seeked` off a write because a real element does, and because the
+     scrub gate reads it — a seek is only over when the element says so, and a
+     double that never said so would leave the gate wedged shut in every test
+     while working perfectly in a browser. That is the exact shape of bug this
+     file exists to keep out.
+
+     Landing immediately is the fast case, not the only one. `holdSeeks` below is
+     how a test gets the slow one, which is where the gate does its work. */
   Object.defineProperty(video, 'currentTime', {
     get: () => currentTime,
     set: (position: number) => {
       currentTime = position
+      control.writes.push(position)
+
+      if (!control.held) video.dispatchEvent(new Event('seeked'))
     },
     configurable: true,
   })
@@ -62,6 +94,31 @@ export const playable = (
 
   return video
 }
+
+/* A clip whose seeks are in flight and have not landed. The mockup gate measured
+   a median of 49 ms for one on a buffered clip, against a pointer stream arriving
+   every few milliseconds — so this, not the instant landing above, is what a drag
+   actually meets, and it is the only condition under which the gate does anything
+   at all.
+
+   Returns the lander: calling it announces that the outstanding seek arrived, the
+   way the element would. */
+export const holdSeeks = (video: HTMLVideoElement) => {
+  const control = controlFor(video)
+
+  control.held = true
+
+  return () => {
+    control.held = false
+    video.dispatchEvent(new Event('seeked'))
+  }
+}
+
+/* Every position written to the element, in order. What a test needs to say that
+   the positions between the first and the newest were never issued — an assertion
+   the element's final `currentTime` cannot make, because a queue and a gate agree
+   about where the drag ended and disagree about everything on the way. */
+export const seeksSeen = (video: HTMLVideoElement) => [...controlFor(video).writes]
 
 /* A clip reaching its own end, in the order a browser does it: the element stops
    *first* and `ended` announces it afterwards — the state change precedes the

--- a/mockup/src/Player.jsx
+++ b/mockup/src/Player.jsx
@@ -295,7 +295,25 @@ function BigButton({ label, active, onClick, children }) {
    The container stays `pointer-events-none` and only the grab strip takes them
    back: the video surface is the play/pause target, so a bar that swallowed the
    whole bottom of the frame would cost you tapping the clip to pause it. */
-function VideoProgress({ time, duration, loop, looping, onScrub, rounded }) {
+/* The drag is 1:1 with the finger, and stays that way. Velocity-adaptive gain
+   and the iPhone's drag-down precision modes were both built here and tried
+   against it on 2026-09-07; both lost. The bar felt wrong because seeks were
+   queueing behind the finger, not because a pixel was worth the wrong number of
+   seconds, and no gain curve fixes latency. Gain that varies also gives up the
+   one property this has and the loop slider does not — drag out and back and you
+   land exactly where you started.
+
+   What buys precision instead is #21's rescale, which is reversible, visible,
+   and already there. */
+function VideoProgress({
+  time,
+  duration,
+  loop,
+  looping,
+  onScrub,
+  onHold,
+  rounded,
+}) {
   const track = useRef(null)
   const [dragging, setDragging] = useState(false)
 
@@ -335,10 +353,26 @@ function VideoProgress({ time, duration, loop, looping, onScrub, rounded }) {
     return domain.from + ratio * span
   }
 
+  const grab = (event) => {
+    setDragging(true)
+    onHold?.(true)
+    onScrub(timeAt(event.clientX))
+  }
+
+  const move = (event) => {
+    if (dragging) onScrub(timeAt(event.clientX))
+  }
+
+  const letGo = () => {
+    setDragging(false)
+    onHold?.(false)
+  }
+
   return (
     <div
       className={`pointer-events-none absolute inset-x-0 bottom-0 select-none bg-gradient-to-t from-black/70 to-transparent px-2 pb-2 pt-8 ${rounded}`}
     >
+
       {/* Two facts, and the row has room for both. Left: what the bar spans, shown
           only when that is no longer the whole clip — without it a playhead
           sitting mid-bar at 01:03 of a 02:28 clip is simply wrong-looking, and
@@ -361,19 +395,21 @@ function VideoProgress({ time, duration, loop, looping, onScrub, rounded }) {
         className="group pointer-events-auto -my-3 cursor-pointer touch-none py-3"
         onPointerDown={(event) => {
           event.currentTarget.setPointerCapture?.(event.pointerId)
-          setDragging(true)
-          onScrub(timeAt(event.clientX))
+          grab(event)
         }}
-        onPointerMove={(event) => dragging && onScrub(timeAt(event.clientX))}
+        onPointerMove={move}
         onPointerUp={(event) => {
           event.currentTarget.releasePointerCapture?.(event.pointerId)
-          setDragging(false)
+          letGo()
         }}
-        onPointerCancel={() => setDragging(false)}
+        onPointerCancel={letGo}
       >
+        {/* The bar thickens under the thumb the way the iPhone's does. It is not
+            decoration — it is the only confirmation that the drag was caught,
+            and on a phone the finger is covering the knob. */}
         <div
-          className={`relative w-full rounded-full bg-white/20 transition-[height] ${
-            dragging ? 'h-1' : 'h-0.5 group-hover:h-1'
+          className={`relative w-full rounded-full bg-white/25 transition-[height] duration-150 ${
+            dragging ? 'h-1.5' : 'h-0.5 group-hover:h-1'
           }`}
         >
           <div
@@ -381,8 +417,10 @@ function VideoProgress({ time, duration, loop, looping, onScrub, rounded }) {
             style={{ width: `${pct(time)}%` }}
           />
           <div
-            className={`absolute top-1/2 h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow transition-transform ${
-              dragging ? 'scale-100' : 'scale-0 group-hover:scale-100'
+            className={`absolute top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white shadow transition-[height,width,transform] duration-150 ${
+              dragging
+                ? 'h-4 w-4 scale-100'
+                : 'h-3 w-3 scale-0 group-hover:scale-100'
             }`}
             style={{ left: `${pct(time)}%` }}
           />
@@ -418,17 +456,47 @@ function Player({ clip, onBack }) {
     nextPointRef.current = nextPoint
   }, [loop, looping, nextPoint])
 
+  /* Held while a finger is on the scrub bar. Two things stand down for it, and
+     the second is the whole responsiveness fix. */
+  const holdingRef = useRef(false)
+  /* The newest seek the drag has asked for, and whether one is already in
+     flight. Only ever one outstanding: a seek that has not landed yet is not
+     replaced by queueing another behind it, it is replaced by forgetting it. */
+  const pendingRef = useRef(null)
+  const targetRef = useRef(0)
+  const seekingRef = useRef(false)
+  const flushSeekRef = useRef(null)
+
   // enforce the loop far more tightly than timeupdate's ~4hz would
   useEffect(() => {
     let frame
     const tick = () => {
       const video = videoRef.current
       if (video) {
+        /* Backstop only — the drag flushes itself, and `seeked` flushes the
+           next one. This catches a `seeked` that never arrives, which would
+           otherwise wedge the gate shut for the rest of the drag. */
+        flushSeekRef.current?.()
+
         const { a, b } = loopRef.current
-        if (loopingRef.current && b > a && video.currentTime >= b) {
+        /* Dragging to the far end of a rescaled bar lands exactly on B, and this
+           fires on `>= b` — so without standing it down the clip jumps to A
+           while the finger is still at the right-hand edge. */
+        if (
+          !holdingRef.current &&
+          loopingRef.current &&
+          b > a &&
+          video.currentTime >= b
+        ) {
           video.currentTime = a
         }
-        setTime(video.currentTime)
+
+        /* The drawn playhead follows the finger, not the decoder. This line used
+           to run unconditionally, which chained the knob to whatever frame had
+           actually been decoded — so every optimistic update from a scrub was
+           overwritten a frame later and the bar rubber-banded behind the thumb.
+           While the drag holds, `scrub` is the only thing that moves it. */
+        if (!holdingRef.current) setTime(video.currentTime)
       }
       frame = requestAnimationFrame(tick)
     }
@@ -504,9 +572,48 @@ function Player({ clip, onBack }) {
     video.playbackRate = speed
   }
 
+  /* One seek in flight, always to the newest position asked for. A pointermove
+     fires far faster than a seek can land, so assigning currentTime on every one
+     of them builds a queue the decoder then works through late — the clip ends
+     up chasing where the finger was half a second ago, which is the freeze.
+
+     Dropping the intermediate targets instead means a fast drag shows fewer
+     frames but never falls behind, and a slow drag — where seeks land faster
+     than the finger asks for them — still resolves every frame. Exact seeks
+     throughout: fastSeek would snap to keyframes seconds apart and take the
+     frame-by-frame resolution with it. */
+  const flushSeek = () => {
+    const video = videoRef.current
+    const target = pendingRef.current
+
+    if (!video || target === null || seekingRef.current) return
+
+    pendingRef.current = null
+    seekingRef.current = true
+    video.currentTime = target
+  }
+
+  // the rAF loop subscribes once, so it reaches the flush through a ref
+  useEffect(() => {
+    flushSeekRef.current = flushSeek
+  })
+
   const scrub = (t) => {
-    videoRef.current.currentTime = t
+    targetRef.current = t
+    pendingRef.current = t
     setTime(t)
+    flushSeek()
+  }
+
+  /* Release settles the clip exactly where the finger left it. Mid-drag the
+     newest target wins and the rest are dropped, so the last one asked for may
+     well have been dropped too — this is what puts it back. */
+  const holdScrub = (held) => {
+    holdingRef.current = held
+    if (held) return
+
+    pendingRef.current = targetRef.current
+    flushSeek()
   }
 
   const nudge = (delta) => () =>
@@ -612,7 +719,19 @@ function Player({ clip, onBack }) {
                   : 'mx-auto block max-h-[50vh] max-w-full rounded-lg bg-black lg:max-h-[80vh]'
               }
               playsInline
+              /* The default only fetches metadata, so scrubbing past what
+                 happens to have arrived turns every seek into a network fetch
+                 and a decode — which is most of what reads as the clip freezing.
+                 These are ~6MB and the app is cache-first anyway, so there is no
+                 reason not to have the whole thing before the first drag. */
+              preload="auto"
               onLoadedMetadata={onLoadedMetadata}
+              /* The gate. The next seek goes out when the last one lands, so
+                 there is never a queue to fall behind. */
+              onSeeked={() => {
+                seekingRef.current = false
+                flushSeek()
+              }}
               onPlay={() => setPlaying(true)}
               onPause={() => setPlaying(false)}
               onClick={togglePlay}
@@ -624,6 +743,7 @@ function Player({ clip, onBack }) {
               loop={loop}
               looping={looping}
               onScrub={scrub}
+              onHold={holdScrub}
               /* Follows the clip's own corners so the scrim doesn't square off a
                  rounded video. Zen has no rounding to follow. */
               rounded={zen ? undefined : 'rounded-b-lg'}


### PR DESCRIPTION
Closes #23. Re-cuts #19.

## What this is

#21 shipped the scrub bar. Driving it for real found it fighting the thumb — "it
freezes and goes to another frame" — and #19 has claimed since it was written that the
answer was iPhone-style velocity-adaptive gain.

**It wasn't, and this proves it by building it.** A mockup gate put three feels side by
side and drove them: direct 1:1, #19's velocity curve, and the drag-down precision modes
#19 rejected sight-unseen. Direct 1:1 won, and it was not close.

The bar felt wrong because **seeks were queueing behind the finger**, not because a pixel
was worth the wrong number of seconds. No gain curve fixes latency. Two of the three modes
were tuning a problem the bar did not have.

Measured in Chrome on a buffered 26.7s clip:

| drag size | median seek | max |
| --- | --- | --- |
| frame-step (0.033s) | **16 ms** | 27 ms |
| small (0.2s) | 49 ms | 77 ms |
| large (1.5s) | 51 ms | 88 ms |

A slow drag resolves at ~60/sec — genuinely frame by frame, which is the thing #19 existed
to buy. A fast drag steps at ~20/sec and so reads as stepping rather than fast-forward.
That ceiling is a real browser limit and is not in scope; #21's rescale is what means you
rarely meet it.

## The three fixes

**One seek in flight, always to the newest position** (`seekGate.ts`). A `pointermove`
fires far faster than a seek can land, so assigning `currentTime` on every one built a
queue the decoder worked through late. Every target but the newest is already wrong by the
time it could be issued, so the gate forgets them rather than promising them. `pending` is
one slot and never a list, because a list is the bug.

Dragging 50 → 100 → 120 → 150 issued `[3, 6, 7.2, 9]` before and issues `[3, 9]` after —
which is the only assertion that can tell a gate from a queue, since both agree about
where the drag ended.

**The marker follows the finger, not the decoder.** BR-07 samples `currentTime` every
frame, so mid-drag it snapped the fill back to wherever the decoder had got to — the finger
at 75% and the bar at 25% underneath it. `adjusting` already stood enforcement down under
BR-19 for the same reason one step further along; the marker now stands down with it.

**`preload="auto"`.** The default fetches metadata and stops, so scrubbing past what
happened to arrive made every seek a network fetch *plus* a decode. Chrome held 4.9s of a
26.7s clip on localhost.

## Two things worth a reviewer's attention

**The test double had to learn to seek.** `media.ts` said outright that jsdom fires no
`seeked` and that "nothing reads those" — true until this branch. A double that never
fired one would have wedged the gate shut in every test while working perfectly in a
browser, which is exactly the class of bug that file exists to keep out. `playable` now
fires `seeked` off a write; `holdSeeks` gives a test the slow case a real drag meets.

**Step 4 turned out to need no production code.** The plan expected a remembered "last
position"; the test found the gate already guaranteed it, because the position the finger
lifts at is by definition never superseded. The commit is the test plus the deletion of the
ref step 2 had added in anticipation.

## Deliberately not here

- **Velocity gain** — rejected by experiment, written up on #19.
- **Frame stepping and fps derivation** — still open; #19 is re-scoped to exactly that.
- **`fastSeek`** — tried and removed. It snaps to keyframes seconds apart, so it *is* the
  freeze it looks like a cure for, and it would take the frame-by-frame resolution with it.
  Called out in a comment at the seek site so it does not come back as an optimisation.

## Verification

`node scripts/verify.mjs` → **GATE: PASS**, 7 checks green, 5 skipped. 770 app tests.

Not smoke-tested on the phone. The three criteria #21 could not cover in jsdom
(thumb-grabbable, drag not scrolling, tap-to-pause not swallowed) are untouched by this and
remain uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUsB7vVjVdhP5yf6QwuUZu
