### PR TITLE
#25 the clip goes quiet while a hand is on it

### DIFF
--- a/app/src/player/PlayerScreen.test.tsx
+++ b/app/src/player/PlayerScreen.test.tsx
@@ -2660,6 +2660,66 @@ describe('scrubbing faster than the seeks can land', () => {
     expect(clip.currentTime).toBe(9)
   })
 
+  /* #23 made a slow drag resolve frame by frame, which is the thing the bar
+     exists for — and every one of those frames lands its own fragment of sound.
+     Dragging slowly through two seconds of a turn is a burst of clicks and
+     half-syllables, and the finer the scrub the worse it gets: the same backwards
+     relationship #21's rescale was built to break.
+
+     Riding on `adjusting` rather than on the bar, so it covers every surface that
+     drags the playhead — the scrub bar and both loop handles. */
+  describe('the sound while a hand is on the clip', () => {
+    it('goes quiet for the length of the drag', () => {
+      const clip = aReadyClip({ seconds: 12 })
+
+      dragAcross(50, 150)
+
+      expect(clip.muted).toBe(true)
+    })
+
+    it('comes back when the bar is let go', () => {
+      const clip = aReadyClip({ seconds: 12 })
+
+      dragAcross(50, 150)
+      fireEvent.pointerUp(aLaidOutBar(), { pointerId: 1 })
+
+      expect(clip.muted).toBe(false)
+    })
+
+    /* Put back the way it was, not switched on. A dancer practising silently in a
+       studio has the clip muted already, and a scrub that handed them audio would
+       be a worse bug than the one this fixes. */
+    it('leaves a clip the dancer had already muted alone', () => {
+      const clip = aReadyClip({ seconds: 12 })
+      clip.muted = true
+
+      dragAcross(50, 150)
+      fireEvent.pointerUp(aLaidOutBar(), { pointerId: 1 })
+
+      expect(clip.muted).toBe(true)
+    })
+
+    /* Both surfaces, not just the bar. Dragging A or B seeks continuously too,
+       and what comes out is the clip sped up or slowed to whatever rate the hand
+       is moving at — the same noise arriving by a different route. */
+    it('goes quiet while a loop boundary is being dragged', () => {
+      const clip = aReadyClip({ seconds: 12 })
+
+      fireEvent.pointerDown(boundary('Loop start'), { pointerId: 1, clientX: 0 })
+
+      expect(clip.muted).toBe(true)
+    })
+
+    it('brings the sound back when the boundary is let go', () => {
+      const clip = aReadyClip({ seconds: 12 })
+
+      fireEvent.pointerDown(boundary('Loop start'), { pointerId: 1, clientX: 0 })
+      fireEvent.pointerUp(boundary('Loop start'), { pointerId: 1 })
+
+      expect(clip.muted).toBe(false)
+    })
+  })
+
   /* The other half of keeping up, and the one that is visible rather than
      measurable. Dropping the queue stops the clip falling behind; this stops the
      *bar* falling behind, which is what the thumb is actually watching.

--- a/app/src/player/PlayerScreen.tsx
+++ b/app/src/player/PlayerScreen.tsx
@@ -369,6 +369,39 @@ function OpenedClip({
      too, where settling an idle gate is a no-op. */
   const seekLanded = () => issue(settled(gate.current))
 
+  /* Whether the clip was already silent when the bar was taken hold of, so
+     letting go can put the sound back the way it was rather than switching it
+     on. A dancer practising silently in a studio has the clip muted already, and
+     a scrub that handed them audio would be a worse bug than the one below. */
+  const mutedBefore = useRef(false)
+
+  /* The clip goes quiet for as long as a hand is on it. #23 made a slow drag
+     resolve frame by frame — the thing the bar exists for — and every one of
+     those frames lands its own fragment of sound, so scanning slowly through a
+     turn is a burst of clicks and half-syllables. The finer the scrub the worse
+     it gets, which is the backwards relationship #21's rescale was built to
+     break.
+
+     Both surfaces, not just the bar. Dragging A or B seeks continuously too, and
+     what comes out is the clip sped up or slowed to whatever rate the hand
+     happens to be moving at — the same noise arriving by a different route.
+
+     It rides on `adjusting` because that is already the app's answer to "is the
+     dancer holding the playhead", set by the scrub bar and both loop handles
+     (BR-19). A second flag tracking the same fact could only ever disagree with
+     it. */
+  const hushWhileHeld = (held: boolean) => {
+    const video = surface.current
+
+    if (video) {
+      if (held) mutedBefore.current = video.muted
+
+      video.muted = held || mutedBefore.current
+    }
+
+    setAdjusting(held)
+  }
+
   /* Written straight onto the element, because `playbackRate` is a property
      rather than an attribute React could render. Nothing here plays, pauses or
      touches `looping`, and the enforcement below does not take the rate as a
@@ -805,7 +838,7 @@ function OpenedClip({
                   loop={playback.loop}
                   looping={playback.looping}
                   onScrub={seekTo}
-                  onHold={setAdjusting}
+                  onHold={hushWhileHeld}
                   rounded={isolated ? undefined : 'rounded-b-lg'}
                 />
               )}
@@ -878,7 +911,7 @@ function OpenedClip({
                   time={time}
                   onSeek={seekTo}
                   onLoopChange={changeLoop}
-                  onHold={setAdjusting}
+                  onHold={hushWhileHeld}
                 />
               )}
             </div>

--- a/mockup/src/Player.jsx
+++ b/mockup/src/Player.jsx
@@ -148,7 +148,7 @@ function SpeedStepper({ speed, onChange }) {
   )
 }
 
-function LoopSlider({ duration, time, loop, onScrub, onLoopChange }) {
+function LoopSlider({ duration, time, loop, onScrub, onLoopChange, onHold }) {
   const trackRef = useRef(null)
   const [dragging, setDragging] = useState(null)
 
@@ -160,6 +160,7 @@ function LoopSlider({ duration, time, loop, onScrub, onLoopChange }) {
   const startDrag = (handle) => (event) => {
     event.currentTarget.setPointerCapture(event.pointerId)
     setDragging(handle)
+    onHold?.(true)
   }
 
   const onPointerMove = (event) => {
@@ -177,6 +178,7 @@ function LoopSlider({ duration, time, loop, onScrub, onLoopChange }) {
     if (!dragging) return
     event.currentTarget.releasePointerCapture(event.pointerId)
     setDragging(null)
+    onHold?.(false)
   }
 
   const pct = (t) => (duration ? (t / duration) * 100 : 0)
@@ -605,11 +607,30 @@ function Player({ clip, onBack }) {
     flushSeek()
   }
 
-  /* Release settles the clip exactly where the finger left it. Mid-drag the
+  /* The clip goes quiet for as long as a hand is on it. Scrubbing resolves frame
+     by frame now, and every one of those frames lands its own fragment of sound —
+     scanning slowly through a turn is a burst of clicks and half-syllables, and
+     the finer the scrub the worse it gets. Dragging A or B is the same noise by a
+     different route: the clip sped up or slowed to whatever rate the hand happens
+     to be moving at.
+
+     Put back the way it was rather than switched on, because a clip practised
+     silently is already muted and handing it audio would be worse than the noise
+     this removes. */
+  const mutedBefore = useRef(false)
+
+  /* Release also settles the clip exactly where the finger left it. Mid-drag the
      newest target wins and the rest are dropped, so the last one asked for may
      well have been dropped too — this is what puts it back. */
   const holdScrub = (held) => {
     holdingRef.current = held
+
+    const video = videoRef.current
+    if (video) {
+      if (held) mutedBefore.current = video.muted
+      video.muted = held || mutedBefore.current
+    }
+
     if (held) return
 
     pendingRef.current = targetRef.current
@@ -779,6 +800,7 @@ function Player({ clip, onBack }) {
             loop={loop}
             onScrub={scrub}
             onLoopChange={changeLoop}
+            onHold={holdScrub}
           />
 
           {/* Only worth showing where there is a keyboard to press */}


### PR DESCRIPTION
Closes #25.

## What this is

#23 made a slow drag resolve frame by frame — the thing the scrub bar exists for — and
every one of those frames lands its own fragment of sound. Scanning slowly through two
seconds of a turn is a burst of clicks and half-syllables, and **the finer the scrub the
worse it gets**, which is the same backwards relationship #21's rescale was built to
break.

So the clip goes quiet for as long as a hand is on it.

## Scope widened during implementation

Cut as the scrub bar only, on the reasoning that A and B are often framed *by ear*. That
turned out to be wrong: a handle drag does not produce the clip playing at its own rate,
it produces the clip sped up or slowed to whatever rate the hand is moving at — the same
noise by a different route, with nothing to listen to. So **both loop handles too**. The
ticket body records the change and why.

## Restored, not unmuted

The clip's muted state is remembered when the hand lands and put back on release. A dancer
practising silently in a studio has it muted already, and a scrub that handed them audio
would be a worse bug than the noise this removes. That is its own criterion and its own
test.

## Where it hangs

On `adjusting`, which is already the app's answer to "is the dancer holding the playhead"
(BR-19) and is set by all three surfaces. A second flag tracking the same fact could only
ever disagree with it. That flag now has three consumers: loop enforcement, the marker
(#23), and the sound.

## Mockup

Given the same behaviour, and its `LoopSlider` gains the `onHold` it never had — the app's
already reported through one, so without it the mockup could not be a true reference for
the half of this that is about the handles.

## Verification

`node scripts/verify.mjs` → **GATE: PASS**, 7 checks green, 5 skipped. 775 app tests, five
of them new.

Not smoke-tested — `muted` is a property jsdom implements, so the tests are real, but
nobody has yet heard it go quiet on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUsB7vVjVdhP5yf6QwuUZu
